### PR TITLE
Fix root-relative paths to work on Federalist

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -93,9 +93,9 @@
     <header class="usa-header usa-header--extended">
       <div class="usa-navbar">
         <div id="extended-logo" class="usa-logo">
-          <em class="usa-logo__text"><a href="/" title="Home" aria-label="Home">{{
+          <em class="usa-logo__text"><nuxt-link to="/" title="Home" aria-label="Home">{{
               $t("projectName")
-            }}</a></em>
+            }}</nuxt-link></em>
         </div>
         <button class="usa-menu-btn">Menu</button>
       </div>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import CopyPlugin from 'copy-webpack-plugin';
 
-const sitePrefix = process.env.SITE_PREFIX ? `/${process.env.SITE_PREFIX}/` : '/'
+const sitePrefix = process.env.BASEURL ? `/${process.env.BASEURL}/` : '/'
 
 export default {
   // Target: https://go.nuxtjs.dev/config-target

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import CopyPlugin from 'copy-webpack-plugin';
 
-const sitePrefix = process.env.BASEURL ? `/${process.env.BASEURL}/` : '/'
+const sitePrefix = process.env.SITE_PREFIX ? `/${process.env.SITE_PREFIX}/` : '/'
 
 export default {
   // Target: https://go.nuxtjs.dev/config-target
@@ -19,7 +19,7 @@ export default {
       { hid: 'description', name: 'description', content: 'Default meta tags are in nuxt.config.js' }
     ],
     link: [
-      { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }
+      { rel: 'icon', type: 'image/x-icon', href: sitePrefix + 'favicon.ico' }
     ],
   },
 


### PR DESCRIPTION
We'll need to remember not to use simple `<a>` tags for internal nav -- these must be `<nuxt-link>` in order to get the site prefix from Vue router.

Also, for meta tags declared in [nuxt.config.js](https://github.com/GSA/usagov-benefits-eligibility/blob/main/nuxt.config.js) (favicon, particularly), we need to add the `sitePrefix` variable for the same reason.
