### PR TITLE
turns off no-onchange rule for linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,5 +74,8 @@ module.exports = {
         allowChildren: false,
       },
     ],
+    // https://open-wc.org/docs/linting/eslint-plugin-lit-a11y/rules/no-invalid-change-handler/
+    // Seems to be a thing for older browsers
+    "vuejs-accessibility/no-onchange": ["off"],
   },
 }


### PR DESCRIPTION
🤔 also an [open issue](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/issues/97) making good points.
