### PR TITLE
Add title to GTM iframe

### DIFF
--- a/components/GoogleTagManagerHeader.vue
+++ b/components/GoogleTagManagerHeader.vue
@@ -2,7 +2,7 @@
   <div>
     <noscript v-if="$config.tagManagerKey">
       <iframe :src="url"
-              height="0" width="0" style="display:none;visibility:hidden"></iframe>
+              height="0" width="0" style="display:none;visibility:hidden" title="GoogleTagManager"></iframe>
     </noscript>
   </div>
 </template>


### PR DESCRIPTION
SonarQube complained that the `<iframe>` tag should have a `title` attribute, so I added one.

![Screenshot_2022-04-29_13-06-09](https://user-images.githubusercontent.com/87149725/165991163-b779f442-8a13-4f7b-a636-0f8280ffd082.png)