### PR TITLE
Add comments to GTM templates

### DIFF
--- a/components/GoogleTagManagerFooter.vue
+++ b/components/GoogleTagManagerFooter.vue
@@ -1,5 +1,7 @@
 <template>
+  <!-- Google Tag Manager footer starts here -->
   <div></div>
+  <!-- Google Tag Manager footer ends here -->
 </template>
 
 <script>

--- a/components/GoogleTagManagerHeader.vue
+++ b/components/GoogleTagManagerHeader.vue
@@ -1,10 +1,12 @@
 <template>
+  <!-- Google Tag Manager header starts here -->
   <div>
     <noscript v-if="$config.tagManagerKey">
       <iframe :src="url"
               height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
   </div>
+  <!-- Google Tag Manager header ends here -->
 </template>
 
 <script>


### PR DESCRIPTION
This adds 4 comments to the GTM templates so that we can verify they're working via "View page source" in a browser.