### PR TITLE
Add 'rel="noopener"' to _blank links

### DIFF
--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -50,6 +50,7 @@
               class="usa-link"
               :href="sanitizedBenefitUrl(benefit)"
               target="_blank"
+              rel="noopener"
               >{{ benefit.source.name }}</a
             >
             <!-- //NOSONAR -->
@@ -77,6 +78,7 @@
             <a
               :href="sanitizedBenefitUrl(benefit)"
               target="_blank"
+              rel="noopener"
               :aria-label="`How to apply for ${benefit.title}`"
               class="usa-button print:display-none">
               {{ $t("accordion.apply") }}


### PR DESCRIPTION
SonarQube was complaining about two links not having the aforementioned
attribute, so I added it.  Tests pass.