### PR TITLE
Back Button Fix

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,7 +69,7 @@ export default {
   },
   mounted() {
     if (this.$config.oneEventVersion !== false) {
-      this.$router.push(this.$route.fullPath + this.$config.oneEventVersion)
+      this.$router.replace(this.$route.fullPath + this.$config.oneEventVersion)
     }
     this.landingPage = tObj.call(this, this.landingPage)
   },

--- a/test/pages/LifeEvents.spec.js
+++ b/test/pages/LifeEvents.spec.js
@@ -41,7 +41,7 @@ describe("LifeEventsPage", () => {
       fullPath: "/death-of-a-loved-one",
     }
     config.mocks.$router = {
-      push: jest.fn(),
+      replace: jest.fn(),
     }
     await beforeAllTests()
   })


### PR DESCRIPTION
We are now using `this.$router.replace...` instead of `this.$router.push..` which fixes the issue of the back button not working on all platforms. Now we are not adding another entry to the history stack we are just redirecting.