### PR TITLE
574 nvmrc

### DIFF
--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -21,19 +21,22 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@v3
+  
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
 
-      - name: Use Node.js
+      - name: Use Node.js (.nvmrc)
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Test accessibility with pa11y
         run: |
-          which google-chrome \
-          && npm run dev & \
+          npm run dev & \
           timeout 120s \
             sh -c 'until nc -z localhost 3000; do sleep 1; done' \
           && sleep 120 \

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Checkout source
         uses: actions/checkout@v3
-  
+
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v2
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+
+      - name: Use Node.js (.nvmrc)
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
closes #574

This update replaces the `actions/setup-node` step that uses a hard-coded Node version with a two-step process that reads the `.nvmrc` file and uses that `actions/setup-node` step with the version read from the project.