### PR TITLE
561 megalinter6

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.github.io/flavors/
-        uses: megalinter/megalinter@v5
+        uses: megalinter/megalinter@v6
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/
@@ -48,7 +48,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: MegaLinter reports
           path: |

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -36,7 +36,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.github.io/flavors/
-        uses: megalinter/megalinter@v6
+        uses: oxsecurity/megalinter/flavors/javascript@v6
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/


### PR DESCRIPTION
closes #561 

This bumps Megalinter to v6 and uses the "JavaScript" flavor.  Changing the flavor cuts runtime from ~ 4 minutes to ~ 1.5 minutes.

This also bumps actions/upload-artifact and actions/checkout to their latest major versions.