### PR TITLE
Megalinter tidy

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,7 +3,7 @@ name: Snyk Scan
 
 # yamllint disable-line rule:truthy
 on:
-#  pull_request:
+  #  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,7 +3,7 @@ name: Snyk Scan
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
+#  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ yarn-error.log*
 dist
 _site
 
-# USWDS 
+# USWDS
 /assets/fonts
 /assets/img
 /assets/js
@@ -44,3 +44,7 @@ report/
 # OWASP ZAP reports
 /report.md
 /zap.yaml
+
+# Don't grab Megalinter reports
+/megalinter-reports/
+/reports/

--- a/github_conf/branch_protection_rules.json
+++ b/github_conf/branch_protection_rules.json
@@ -1,0 +1,4 @@
+{
+    "message": "Not Found",
+    "documentation_url": "https://docs.github.com/rest"
+}


### PR DESCRIPTION
Snyk's running over its monthly limit because Megalinter reports are being added to the repo which is triggering Megalinter to run [...] so this disables running Snyk on PR (should be refactored to run periodically) and makes sure git won't stage generated reports.