### PR TITLE
613 inhibit git related megalinter warnings fatma

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -14,8 +14,6 @@ env: # Comment env block if you do not want to apply fixes
   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
   APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
   APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
-  REPOSITORY_GITLEAKS_ARGUMENTS: --no-git # only scan the files in This commit, not the entire history of the repo
-  REPOSITORY_DEVSKIM_ARGUMENTS: --skip-git-ignored-files # don't lint the generated code in the docs/ directory
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -15,7 +15,7 @@ env: # Comment env block if you do not want to apply fixes
   APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
   APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
   REPOSITORY_GITLEAKS_ARGUMENTS: --no-git # only scan the files in This commit, not the entire history of the repo
-  REPOSITORY_DEVSKIM_ARGUMENTS: --skip-git-ignored-files  # don't lint the generated code in the docs/ directory
+  REPOSITORY_DEVSKIM_ARGUMENTS: --skip-git-ignored-files # don't lint the generated code in the docs/ directory
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -14,6 +14,8 @@ env: # Comment env block if you do not want to apply fixes
   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
   APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
   APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
+  REPOSITORY_GITLEAKS_ARGUMENTS: --no-git # only scan the files in This commit, not the entire history of the repo
+  REPOSITORY_DEVSKIM_ARGUMENTS: --skip-git-ignored-files  # don't lint the generated code in the docs/ directory
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -22,3 +22,9 @@ DISABLE_ERRORS: true
 
 # use prettier for JavaScript code formatting
 JAVASCRIPT_DEFAULT_STYLE: prettier
+
+# only scan the files in This commit, not the entire history of the repo
+REPOSITORY_GITLEAKS_ARGUMENTS: --no-git
+
+# don't lint the generated code in the docs/ directory
+REPOSITORY_DEVSKIM_ARGUMENTS: --skip-git-ignored-files


### PR DESCRIPTION
Made the below additions to the megalinter.yml to prevent overly exuberant scanning.

# only scan the files in This commit, not the entire history of the repo
REPOSITORY_GITLEAKS_ARGUMENTS: --no-git

# don't lint the generated code in the docs/ directory
REPOSITORY_DEVSKIM_ARGUMENTS: --skip-git-ignored-files