### PR TITLE
Update Megalinter event triger to pull_request

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -5,8 +5,8 @@ name: MegaLinter
 
 # yamllint disable-line rule:truthy
 on:
-  # Trigger mega-linter at every push. Action will also be visible from Pull Requests to main
-  push:
+  # Triggers mega-linter when a pull_request event's activity type is opened, synchronize, or reopened by default.
+  pull_request:
   workflow_dispatch:
 
 env: # Comment env block if you do not want to apply fixes


### PR DESCRIPTION
This PR updates Megalinter event trigger to `pull_request` instead of `push`.