### PR TITLE
implementing branch-based federalist script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:pa11y": "pa11y http://localhost:3000/",
     "federalist:nuxtjsbug": "open https://github.com/nuxt/nuxt.js/issues/8973",
     "federalist:local": "gulp && nuxt generate && cd ./_site/_nuxt/css && perl -pi -e 's/url\\(\\/fonts/url\\(..\\/fonts/g' *.css && cd ../../.. && ls -lhR _site && nuxt start",
-    "federalist": "gulp && nuxt generate && cd ./_site/_nuxt/css && sed -i~ -Ee 's|(/?)fonts/|\\1../fonts/|g' *.css && cd ../../.. && ls -lhR _site",
+    "federalist": "gulp && nuxt generate ; cd ./_site/_nuxt/css && if [ \"${BRANCH}\" = \"main\" ] || [ \"${BRANCH}\" = \"release\" ]; then sed -i~ -Ee 's|(/?)fonts/|\\1../fonts/|g' *.css; else perl -pi -e 's/\\/fonts\\//\\/_nuxt\\/fonts\\//g' *.css; fi && cd ../../.. && ls -lhR _site",
     "format": "prettier --write \"./**/*.{js,jsx,json,vue,md,css}\""
   },
   "dependencies": {


### PR DESCRIPTION
This PR makes a change with the `package.json` file so that the `federalist` script gets executed based on the branch.

It resolves the issue in #647 .