### PR TITLE
#610 Fix DOM - Safari does not update

### DIFF
--- a/services/dateHelper.js
+++ b/services/dateHelper.js
@@ -30,7 +30,7 @@ function validateDateAgainstAcceptance({ criterion, userInputDate }) {
       ) {
         acceptanceDate = figureOutAcceptanceDate(encodedDate, determiner)
       } else {
-        acceptanceDate = toDate(Date.parse(encodedDate))
+        acceptanceDate = toDate(dateParse(encodedDate))
       }
       checkResult = checkUserDate(userInputDate, determiner, operator, acceptanceDate)
       // checking to see if the inputted date is valid / complete
@@ -139,4 +139,12 @@ function checkDateValid(month, day, year) {
   return validityCheck === INCOMPLETE ? "" : validityCheck
 }
 
-export { validateDateAgainstAcceptance, checkDateValid }
+function dateParse(inputDate) {
+  const m = inputDate.match(/^(\d{1,2})-(\d{1,2})-(\d{4})$/)
+  if (m) {
+    inputDate = m[1] + "/" + m[2] + "/" + m[3]
+  }
+  return Date.parse(inputDate)
+}
+
+export { validateDateAgainstAcceptance, checkDateValid, dateParse }

--- a/services/dateHelper.js
+++ b/services/dateHelper.js
@@ -140,7 +140,7 @@ function checkDateValid(month, day, year) {
 }
 
 function dateParse(inputDate) {
-  const m = inputDate.match(/^(\d{1,2})-(\d{1,2})-(\d{4})$/)
+  const m = String(inputDate).match(/^(\d{1,2})-(\d{1,2})-(\d{4})$/)
   if (m) {
     inputDate = m[1] + "/" + m[2] + "/" + m[3]
   }

--- a/store/criteria.js
+++ b/store/criteria.js
@@ -1,6 +1,6 @@
 import Vue from "vue"
 import stringToHash from "../services/stringToHash"
-import { validateDateAgainstAcceptance } from "~/services/dateHelper"
+import { validateDateAgainstAcceptance, dateParse } from "~/services/dateHelper"
 
 export const state = () => ({
   eligibilityCriteria: {},
@@ -75,8 +75,8 @@ export const getters = {
     }
     // need this to be swapped if passing in a state I.E. testing
     const userInputDate = criterion.test
-      ? Date.parse(theGetters.getResponseByEligibilityKey(theState)(criterion.criteriaKey))
-      : Date.parse(theGetters.getResponseByEligibilityKey(criterion.criteriaKey))
+      ? dateParse(theGetters.getResponseByEligibilityKey(theState)(criterion.criteriaKey))
+      : dateParse(theGetters.getResponseByEligibilityKey(criterion.criteriaKey))
     return validateDateAgainstAcceptance({
       criterion,
       userInputDate,


### PR DESCRIPTION
Fix issue of "COVID-19 Funeral Assistance: DOM in Safari does not update when The deceased's funeral/burial date is on or after 01/21/2020".

## Testing
Test on this branch, `610-safari-date`