### PR TITLE
#659 - allow for console.log in dev

### DIFF
--- a/.env.txt
+++ b/.env.txt
@@ -1,0 +1,4 @@
+## To use this file, rename this to .env which is already ignored by git.
+
+## Enable console.log for your local dev environment.
+VUE_APP_CONSOLE_LOG=true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   rules: {
     "comma-dangle": 0,
     semi: ["off"],
+    "no-console": 1,
     quotes: ["off"],
     indent: ["off"],
     "jsx-a11y/click-events-have-key": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
   rules: {
     "comma-dangle": 0,
     semi: ["off"],
-    "no-console": 1,
     quotes: ["off"],
     indent: ["off"],
     "jsx-a11y/click-events-have-key": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     semi: ["off"],
     quotes: ["off"],
     indent: ["off"],
+    "no-console": 0,
     "jsx-a11y/click-events-have-key": "off",
     "padded-blocks": ["off"],
     "vue/singleline-html-element-content-newline": 0,

--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -78,7 +78,7 @@ import _ from "lodash"
 import { mapGetters } from "vuex"
 import mapTags from "~/mixins/MapTags"
 import sanitizeUrl from "~/mixins/SanitizeBears"
-console.log("hello")
+console.log("hello there")
 
 let USWDS
 let accordion

--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -78,7 +78,8 @@ import _ from "lodash"
 import { mapGetters } from "vuex"
 import mapTags from "~/mixins/MapTags"
 import sanitizeUrl from "~/mixins/SanitizeBears"
-console.log("hello Gene")
+
+console.log("This will only be logged in the local development environment.")
 
 let USWDS
 let accordion

--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -78,7 +78,7 @@ import _ from "lodash"
 import { mapGetters } from "vuex"
 import mapTags from "~/mixins/MapTags"
 import sanitizeUrl from "~/mixins/SanitizeBears"
-console.log("hello there")
+console.log("hello Gene")
 
 let USWDS
 let accordion

--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -78,6 +78,7 @@ import _ from "lodash"
 import { mapGetters } from "vuex"
 import mapTags from "~/mixins/MapTags"
 import sanitizeUrl from "~/mixins/SanitizeBears"
+console.log("hello")
 
 let USWDS
 let accordion

--- a/components/Accordion.vue
+++ b/components/Accordion.vue
@@ -79,8 +79,6 @@ import { mapGetters } from "vuex"
 import mapTags from "~/mixins/MapTags"
 import sanitizeUrl from "~/mixins/SanitizeBears"
 
-console.log("This will only be logged in the local development environment.")
-
 let USWDS
 let accordion
 /* istanbul ignore if */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -137,6 +137,14 @@ export default {
         config.output.publicPath = sitePrefix
       }
     },
+    terser: {
+      // https://github.com/terser/terser#compress-options
+      terserOptions: {
+        compress: {
+          drop_console: true,
+        },
+      },
+    },
   },
 
   generate: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -139,6 +139,7 @@ export default {
     },
     terser: {
       // https://github.com/terser/terser#compress-options
+      // Exclude console.logs from prod builds. ( drop_console: true).
       terserOptions: {
         compress: {
           drop_console: true,

--- a/plugins/axe.client.js
+++ b/plugins/axe.client.js
@@ -1,11 +1,13 @@
 import Vue from "vue"
 
 export default function () {
-  if (process.env.NODE_ENV === "development") {
-    const VueAxe = require("vue-axe").default
+  const VueAxe = require("vue-axe").default
+  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
     Vue.use(VueAxe, {
-      // Allow console.log on local
+      // Allow console.log on local.
       allowConsoleClears: false,
     })
+  } else if (process.env.NODE_ENV === "development") {
+    Vue.use(VueAxe)
   }
 }

--- a/plugins/axe.client.js
+++ b/plugins/axe.client.js
@@ -2,12 +2,15 @@ import Vue from "vue"
 
 export default function () {
   const VueAxe = require("vue-axe").default
-  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+  // If env file is present.
+  if (process.env.VUE_APP_CONSOLE_LOG) {
     Vue.use(VueAxe, {
       // Allow console.log on local.
       allowConsoleClears: false,
     })
-  } else if (process.env.NODE_ENV === "development") {
+  }
+
+  if (process.env.NODE_ENV === "development") {
     Vue.use(VueAxe)
   }
 }

--- a/plugins/axe.client.js
+++ b/plugins/axe.client.js
@@ -4,7 +4,8 @@ export default function () {
   if (process.env.NODE_ENV === "development") {
     const VueAxe = require("vue-axe").default
     Vue.use(VueAxe, {
-      allowConsoleClears: false, // disable all console clears
+      // Allow console.log on local
+      allowConsoleClears: false,
     })
   }
 }

--- a/plugins/axe.client.js
+++ b/plugins/axe.client.js
@@ -3,6 +3,8 @@ import Vue from "vue"
 export default function () {
   if (process.env.NODE_ENV === "development") {
     const VueAxe = require("vue-axe").default
-    Vue.use(VueAxe)
+    Vue.use(VueAxe, {
+      allowConsoleClears: false, // disable all console clears
+    })
   }
 }


### PR DESCRIPTION
## Ticket:
https://github.com/GSA/usagov-benefits-eligibility/issues/659

## Test steps

1. pull this branch locally
2. run `npm run dev` in terminal
3. insert a console.log on line 81 of accordion.vue, e.g. console.log("hello")
4. confirm you see that message in your browser's console
5. Now go to https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/task/659/death-of-a-loved-one/? and make sure _you do not see_ any console.log messages there in the browser console