### PR TITLE
Task/587 look into why pa11y doesn't run locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ to build an image of the BEARS software and run it as a container.
 docker build -t bears . \
 && docker run --rm -it -p 3000:3000 bears
 ```
+### Pa11y testing locally
+
+To implement the pa11y testing locally in a containerized environment, use the following command:
+
+```bash
+(
+  cd "$(git rev-parse --show-toplevel)" \
+  && docker compose up
+)
+```
+You may use the following command to close the running containers:
+
+```bash
+(
+  docker compose down
+)
 
 ### Useful links
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+  bears:
+    build: .
+    container_name: bears
+    ports:
+      - 3000
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:3000"]
+        interval: 30s
+        timeout: 10s
+        retries: 5
+
+  pa11y:
+    image: outrigger/pa11y:1
+    container_name: pa11y
+    command: http://bears:3000/
+    restart: on-failure
+    depends_on:
+      bears:
+        condition: service_healthy
+    cap_add:
+      - SYS_ADMIN  
+    links: 
+      - bears

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     ports:
       - 3000
     healthcheck:
-        test: ["CMD", "curl", "-f", "http://localhost:3000"]
-        interval: 30s
-        timeout: 10s
-        retries: 5
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   pa11y:
     image: outrigger/pa11y:1
@@ -21,6 +21,6 @@ services:
       bears:
         condition: service_healthy
     cap_add:
-      - SYS_ADMIN  
-    links: 
+      - SYS_ADMIN
+    links:
       - bears


### PR DESCRIPTION
### Problem
`pa11y` may not work locally depending on the local environment. It suggest a stable solution to #587.

### Solution
This PR creates a `docker-compose.yml` file that can be used locally to  use `pa11y` and test the application in a containerized environment.

It also provides documentation in the README file.

### Steps to test

Use the following command and see if you can see pa11y findings:
  `cd "$(git rev-parse --show-toplevel)" && docker compose up`
