### PR TITLE
#675 - Fix date field in FireFox not working

### DIFF
--- a/services/dateHelper.js
+++ b/services/dateHelper.js
@@ -127,7 +127,7 @@ function checkDateValid(month, day, year) {
   }
   const validityCheck = validInputs(month, day, year)
   if (validityCheck !== INCOMPLETE && validityCheck !== ERRORMSG) {
-    const checkDate = toDate(Date.parse(month, day, year))
+    const checkDate = toDate(Date.parse(month + "/" + day + "/" + year))
     if (isNaN(checkDate)) {
       return ERRORMSG
     }


### PR DESCRIPTION
## PR Summary

Fix issue #675 [Bug] Date fields in FireFox always outputs "Please enter a valid date" even if a valid date is entered.

## Related Github Issue

- fixes #675

## Type of change

Please delete options that are not relevant.
- [x] Bug fix

## Branch Name
675-firefox-date-field

The name of this branch
#675 - Fix date field in FireFox not working

## Testing environment

https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/675-firefox-date-field/death-of-a-loved-one/?

## Detailed Testing steps

Test remotely
1. open FireFox browser
2. goto https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/675-firefox-date-field/death-of-a-loved-one/?
3. enter valid date in data field - this should work without error message

Test locally
1. pull this branch locally
2. run npm run dev in terminal
3. open FireFox
4. go to http://localhost:3000/death-of-a-loved-one/?
5. enter valid date in data field - this should work without error message

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
