### PR TITLE
#691 - Add read only permissions to github actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,8 @@ on:
   schedule:
     - cron: "20 11 * * 1"
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: read-all
+
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration
   APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)

--- a/.github/workflows/owasp_zap_full.yml
+++ b/.github/workflows/owasp_zap_full.yml
@@ -7,6 +7,8 @@ on:
   schedule:
     - cron: "30 3 * * SAT" # every Saturday at 3:30am
 
+permissions: read-all
+
 jobs:
   ZAP:
     name: OWASP ZAP Full Scan

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: read-all
+
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,6 +8,8 @@ on:
   schedule:
     - cron: "15 12 * * 1"
 
+permissions: read-all
+
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   push:
 
+permissions: read-all
+
 jobs:
   test_frontend:
     name: test frontend

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   push:
 
+permissions: read-all
+
 jobs:
   woke:
     name: woke


### PR DESCRIPTION
## PR Summary

`Code scanning results / Checkov (MegaLinter REPOSITORY_CHECKOV)` were failing with the following error messages for all the github actions: `Ensure top-level permissions are not set to write-all`

This PR implements the solution listed here: [https://github.com/bridgecrewio/checkov/issues/4127](https://github.com/GSA/usagov-benefits-eligibility/issues/url) by adding `permissions: read-all` code block to all github action files.

## Related Github Issue

- fixes #691 

## Type of change

- [x] Bug fix

## Branch Name

bug/691-checkov-megalinter-repository_checkov-fails

## Testing environment

[Link to a Federalist URL .](https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/bug/691-checkov-megalinter-repository_checkov-fails/death-of-a-loved-one/?)

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] When the github actions triggered; Code scanning results / Checkov (MegaLinter REPOSITORY_CHECKOV) should pass with success.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
