### PR TITLE
#654 - Fix keypath warning

### DIFF
--- a/locales/en/benefits/dod-burial-benefits.json
+++ b/locales/en/benefits/dod-burial-benefits.json
@@ -2,6 +2,7 @@
   "dod-burial-benefits.title": "Burial Benefits",
   "dod-burial-benefits.headline": "Burial Benefits",
   "dod-burial-benefits.source.name": "Department of Defense",
+  "dod-burial-benefits.source.linkIsEnglish": "true",
   "dod-burial-benefits.source.link": "https://www.dcms.uscg.mil/Portals/10/CG-1/PSC/PSD/docs/SurvivorsGuide2015.pdf?ver=2017-03-24-132033-397",
   "dod-burial-benefits.summary": "Assistance transporting and intering your loved one may be available, as well as travel support for the surviving spouse, children, and immediate family members of the service member.",
   "dod-burial-benefits.eligibility.acceptableValues": "yes",

--- a/locales/en/benefits/dod-death-gratuity.json
+++ b/locales/en/benefits/dod-death-gratuity.json
@@ -3,6 +3,7 @@
   "dod-death-gratuity.headline": "Death Gratuity",
   "dod-death-gratuity.source.name": "Department of Defense",
   "dod-death-gratuity.source.link": "https://militarypay.defense.gov/Benefits/Death-Gratuity/",
+  "dod-death-gratuity.source.linkIsEnglish": "true",
   "dod-death-gratuity.summary": "Death Gratuity is a tax free payment of $100,000 to eligible survivors of members of the Armed Forces, who died while on active duty or while serving in certain reserve statuses.",
   "dod-death-gratuity.eligibility.acceptableValues": "yes",
   "dod-death-gratuity.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/dod-forgotten-widows-annuity.json
+++ b/locales/en/benefits/dod-forgotten-widows-annuity.json
@@ -3,6 +3,7 @@
   "dod-forgotten-widows-annuity.headline": "Annuity for Certain Military Surviving Spouses",
   "dod-forgotten-widows-annuity.source.name": "Department of Defense",
   "dod-forgotten-widows-annuity.source.link": "https://militarypay.defense.gov/Benefits/",
+  "dod-forgotten-widows-annuity.source.linkIsEnglish": "true",
   "dod-forgotten-widows-annuity.summary": "Commonly referred to as the Annuity for Forgotten Widows, qualified surviving spouses of members of the Uniformed Services may be eligible for financial support.",
   "dod-forgotten-widows-annuity.eligibility.acceptableValues": "yes",
   "dod-forgotten-widows-annuity.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/dod-survivor-benefit-plan.json
+++ b/locales/en/benefits/dod-survivor-benefit-plan.json
@@ -3,6 +3,7 @@
   "dod-survivor-benefit-plan.headline": "Survivor Benefit Plan",
   "dod-survivor-benefit-plan.source.name": "Department of Defense",
   "dod-survivor-benefit-plan.source.link": "https://militarypay.defense.gov/Benefits/Survivor-Benefit-Program/",
+  "dod-survivor-benefit-plan.source.linkIsEnglish": "true",
   "dod-survivor-benefit-plan.summary": "Survivors of deceased active duty service members and some retired and reserve members may be eligible for up to 55% of the member's retired pay.",
   "dod-survivor-benefit-plan.eligibility.acceptableValues": "yes",
   "dod-survivor-benefit-plan.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/doi-financial-assistance-social-services-burial.json
+++ b/locales/en/benefits/doi-financial-assistance-social-services-burial.json
@@ -3,6 +3,7 @@
   "doi-financial-assistance-social-services-burial.headline": "Financial Assistance and Social Services (FASS) - Burial Assistance",
   "doi-financial-assistance-social-services-burial.source.name": "Department of Interior - Indian Affairs",
   "doi-financial-assistance-social-services-burial.source.link": "https://www.bia.gov/bia/ois/dhs/financial-assistance",
+  "doi-financial-assistance-social-services-burial.source.linkIsEnglish": "true",
   "doi-financial-assistance-social-services-burial.summary": "Financial Assistance and Social Services (FASS) program provides funds to assist with the burial expenses of deceased indigent Indians whose estates do not have sufficient resources to meet funeral expenses.",
   "doi-financial-assistance-social-services-burial.eligibility.label": "The deceased was a member of a federally recognized American Indian Tribe or an Alaska Native.",
   "doi-financial-assistance-social-services-burial.eligibility.acceptableValues": "yes"

--- a/locales/en/benefits/doj-public-safety-officers-death-benefit.json
+++ b/locales/en/benefits/doj-public-safety-officers-death-benefit.json
@@ -3,6 +3,7 @@
   "doj-public-safety-officers-death-benefit.headline": "Public Safety Officers' Death Benefits",
   "doj-public-safety-officers-death-benefit.source.name": "U.S. Department of Justice",
   "doj-public-safety-officers-death-benefit.source.link": "https://bja.ojp.gov/program/psob/benefits#vkdfp",
+  "doj-public-safety-officers-death-benefit.source.linkIsEnglish": "true",
   "doj-public-safety-officers-death-benefit.summary": "A one-time benefit is available to eligible survivors of law enforcement officers, firefighters, and other first responders whose deaths were the direct result of an injury sustained in the line of duty on or after September 29, 1976.",
   "doj-public-safety-officers-death-benefit.eligibility.acceptableValues": "spouse",
   "doj-public-safety-officers-death-benefit.eligibility.acceptableValues1": "child",

--- a/locales/en/benefits/doj-public-safety-officers-educational-assistance.json
+++ b/locales/en/benefits/doj-public-safety-officers-educational-assistance.json
@@ -3,6 +3,7 @@
   "doj-public-safety-officers-educational-assistance.headline": "Public Safety Officers' Educational Assistance Program",
   "doj-public-safety-officers-educational-assistance.source.name": "U.S. Department of Justice",
   "doj-public-safety-officers-educational-assistance.source.link": "https://bja.ojp.gov/program/psob/benefits#k00l",
+  "doj-public-safety-officers-educational-assistance.source.linkIsEnglish": "true",
   "doj-public-safety-officers-educational-assistance.summary": "Financial assistance for higher education is available to spouses and children of police, fire, and emergency public safety officers killed in the line of duty.",
   "doj-public-safety-officers-educational-assistance.eligibility.acceptableValues": "spouse",
   "doj-public-safety-officers-educational-assistance.eligibility.acceptableValues1": "child"

--- a/locales/en/benefits/dol-division-of-coal-mine-workers-compensation-spouse.json
+++ b/locales/en/benefits/dol-division-of-coal-mine-workers-compensation-spouse.json
@@ -3,6 +3,7 @@
   "dol-division-of-coal-mine-workers-compensation-spouse.headline": "Division of Coal Mine Workers' Compensation (Black Lung Benefits) for Surviving Spouse",
   "dol-division-of-coal-mine-workers-compensation-spouse.source.name": "Department of Labor",
   "dol-division-of-coal-mine-workers-compensation-spouse.source.link": "https://www.dol.gov/agencies/owcp/dcmwc/filing_guide_survivor",
+  "dol-division-of-coal-mine-workers-compensation-spouse.source.linkIsEnglish": "true",
   "dol-division-of-coal-mine-workers-compensation-spouse.summary": "A compensation is available to survivors of coal miners whose deaths are attributable to pneumoconiosis arising out of coal mine employment.",
   "dol-division-of-coal-mine-workers-compensation-spouse.eligibility.acceptableValues": "spouse"
 }

--- a/locales/en/benefits/fema-covid-19-funeral-assistance.json
+++ b/locales/en/benefits/fema-covid-19-funeral-assistance.json
@@ -3,6 +3,7 @@
   "fema-covid-19-funeral-assistance.headline": "COVID-19 Funeral Assistance",
   "fema-covid-19-funeral-assistance.source.name": "FEMA",
   "fema-covid-19-funeral-assistance.source.link": "https://www.fema.gov/disasters/coronavirus/economic/funeral-assistance",
+  "fema-covid-19-funeral-assistance.source.linkIsEnglish": "true",
   "fema-covid-19-funeral-assistance.summary": "Financial assistance may be available to help with the burial and funeral costs for people who died of COVID-19.",
   "fema-covid-19-funeral-assistance.eligibility.label": "The deceased's funeral/burial was after January 20, 2020."
 }

--- a/locales/en/benefits/ssa-lump-sum-death-benefit.json
+++ b/locales/en/benefits/ssa-lump-sum-death-benefit.json
@@ -3,6 +3,7 @@
   "ssa-lump-sum-death-benefit.headline": "Need text here",
   "ssa-lump-sum-death-benefit.source.name": "Social Security Administration",
   "ssa-lump-sum-death-benefit.source.link": "https://www.ssa.gov/benefits/survivors/ifyou.html#h7",
+  "ssa-lump-sum-death-benefit.source.linkIsEnglish": "true",
   "ssa-lump-sum-death-benefit.summary": "The surviving spouse of a deceased person who qualified for Social Security benefits may be eligible for a $255 financial assistance.",
   "ssa-lump-sum-death-benefit.eligibility.label": "The deceased died within the last two years.",
   "ssa-lump-sum-death-benefit.eligibility.acceptableValues": "spouse",

--- a/locales/en/benefits/ssa-survivor-benefits-child-disabled.json
+++ b/locales/en/benefits/ssa-survivor-benefits-child-disabled.json
@@ -3,6 +3,7 @@
   "ssa-survivor-benefits-child-disabled.headline": "Survivor Benefits for Child with Disabilities",
   "ssa-survivor-benefits-child-disabled.source.name": "Social Security Administration",
   "ssa-survivor-benefits-child-disabled.source.link": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+  "ssa-survivor-benefits-child-disabled.source.linkIsEnglish": "true",
   "ssa-survivor-benefits-child-disabled.summary": "Social Security survivors benefits are paid to a child, stepchild, grandchild, or adopted child of eligible workers. Complete just one application to be considered for all benefits administered by the Social Security Administration.",
   "ssa-survivor-benefits-child-disabled.eligibility.acceptableValues": "child",
   "ssa-survivor-benefits-child-disabled.eligibility.label": "You are at least 18 years old.",

--- a/locales/en/benefits/ssa-survivor-benefits-child.json
+++ b/locales/en/benefits/ssa-survivor-benefits-child.json
@@ -3,6 +3,7 @@
   "ssa-survivor-benefits-child.headline": "Survivor Benefits for Child",
   "ssa-survivor-benefits-child.source.name": "Social Security Administration",
   "ssa-survivor-benefits-child.source.link": "https://www.ssa.gov/benefits/survivors/ifyou.html#h4",
+  "ssa-survivor-benefits-child.source.linkIsEnglish": "true",
   "ssa-survivor-benefits-child.summary": "Social Security survivors benefits are paid to a child, stepchild, grandchild, or adopted child of eligible workers. Complete just one application to be considered for all benefits administered by the Social Security Administration.",
   "ssa-survivor-benefits-child.eligibility.acceptableValues": "child",
   "ssa-survivor-benefits-child.eligibility.label": "You are under 18 years old (under 19 years old if you are a full-time student in an elementary or secondary school).",

--- a/locales/en/benefits/ssa-survivor-benefits-mothers-fathers.json
+++ b/locales/en/benefits/ssa-survivor-benefits-mothers-fathers.json
@@ -3,6 +3,7 @@
   "ssa-survivor-benefits-mothers-fathers.headline": "Survivor Benefits for Spouse with a Child (Mother/Father)",
   "ssa-survivor-benefits-mothers-fathers.source.name": "Social Security Administration",
   "ssa-survivor-benefits-mothers-fathers.source.link": "https://www.ssa.gov/forms/ssa-5.html",
+  "ssa-survivor-benefits-mothers-fathers.source.linkIsEnglish": "true",
   "ssa-survivor-benefits-mothers-fathers.summary": "Social Security survivors benefits might be available to the spouse or divorced spouse providing care for the deceased worker's child. Complete just one application to be considered for all benefits administered by the Social Security Administration.",
   "ssa-survivor-benefits-mothers-fathers.eligibility.acceptableValues": "spouse",
   "ssa-survivor-benefits-mothers-fathers.eligibility.acceptableValues1": "widowed",

--- a/locales/en/benefits/ssa-survivor-benefits-parents.json
+++ b/locales/en/benefits/ssa-survivor-benefits-parents.json
@@ -3,6 +3,7 @@
   "ssa-survivor-benefits-parents.headline": "Survivor Benefits for Parent",
   "ssa-survivor-benefits-parents.source.name": "Social Security Administration",
   "ssa-survivor-benefits-parents.source.link": "https://www.ssa.gov/benefits/survivors/ifyou.html#h5",
+  "ssa-survivor-benefits-parents.source.linkIsEnglish": "true",
   "ssa-survivor-benefits-parents.summary": "Social Security survivors benefits are paid to parents of eligible workers. Complete just one application to be considered for all benefits administered by the Social Security Administration.",
   "ssa-survivor-benefits-parents.eligibility.acceptableValues": "parent",
   "ssa-survivor-benefits-parents.eligibility.label": "You are at least 62 years old and were dependent on the deceased for at least half of your support."

--- a/locales/en/benefits/ssa-survivor-benefits-spouse-disabled.json
+++ b/locales/en/benefits/ssa-survivor-benefits-spouse-disabled.json
@@ -3,6 +3,7 @@
   "ssa-survivor-benefits-spouse-disabled.headline": "Survivor Benefits for Spouse with Disabilities",
   "ssa-survivor-benefits-spouse-disabled.source.name": "Social Security Administration",
   "ssa-survivor-benefits-spouse-disabled.source.link": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+  "ssa-survivor-benefits-spouse-disabled.source.linkIsEnglish": "true",
   "ssa-survivor-benefits-spouse-disabled.summary": "Social Security survivors benefits are paid to a surviving spouse of eligible workers, and under certain circumstances, to a surviving divorced spouse of eligible workers. Complete just one application to be considered for all benefits administered by the Social Security Administration.",
   "ssa-survivor-benefits-spouse-disabled.eligibility.acceptableValues": "spouse",
   "ssa-survivor-benefits-spouse-disabled.eligibility.label": "You are at least 50 years old.",

--- a/locales/en/benefits/ssa-survivor-benefits-spouse.json
+++ b/locales/en/benefits/ssa-survivor-benefits-spouse.json
@@ -3,6 +3,7 @@
   "ssa-survivor-benefits-spouse.headline": "Survivor Benefits for Spouse",
   "ssa-survivor-benefits-spouse.source.name": "Social Security Administration",
   "ssa-survivor-benefits-spouse.source.link": "https://www.ssa.gov/benefits/survivors/ifyou.html#h2",
+  "ssa-survivor-benefits-spouse.source.linkIsEnglish": "true",
   "ssa-survivor-benefits-spouse.summary": "Social Security survivors benefits are paid to a surviving spouse of eligible workers, and under certain circumstances, to a surviving divorced spouse of eligible workers. Complete just one application to be considered for all benefits administered by the Social Security Administration.",
   "ssa-survivor-benefits-spouse.eligibility.acceptableValues": "spouse",
   "ssa-survivor-benefits-spouse.eligibility.label": "You are at least 60 years old.",

--- a/locales/en/benefits/va-burial-allowance.json
+++ b/locales/en/benefits/va-burial-allowance.json
@@ -3,6 +3,7 @@
   "va-burial-allowance.headline": "Veteran's Burial Allowance",
   "va-burial-allowance.source.name": "U.S. Department of Veteran Affairs",
   "va-burial-allowance.source.link": "https://www.va.gov/burials-memorials/veterans-burial-allowance/",
+  "va-burial-allowance.source.linkIsEnglish": "true",
   "va-burial-allowance.summary": "Assistance may be available to help with burial, funeral, and transportation costs of a deceased veteran.",
   "va-burial-allowance.eligibility.acceptableValues": "yes",
   "va-burial-allowance.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-burial-flag.json
+++ b/locales/en/benefits/va-burial-flag.json
@@ -3,6 +3,7 @@
   "va-burial-flag.headline": "Burial Flag",
   "va-burial-flag.source.name": "U.S. Department of Veteran Affairs",
   "va-burial-flag.source.link": "https://www.va.gov/burials-memorials/memorial-items/burial-flags/",
+  "va-burial-flag.source.linkIsEnglish": "true",
   "va-burial-flag.summary": "VA provides a United States flag to drape on a casket (or coffin) or place with an urn in honor of the military service of a veteran or reservist.",
   "va-burial-flag.eligibility.acceptableValues": "yes",
   "va-burial-flag.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-burial-in-national-cemetery.json
+++ b/locales/en/benefits/va-burial-in-national-cemetery.json
@@ -3,6 +3,7 @@
   "va-burial-in-national-cemetery.headline": "Burial in VA National Cemetery",
   "va-burial-in-national-cemetery.source.name": "U.S. Department of Veteran Affairs",
   "va-burial-in-national-cemetery.source.link": "https://www.va.gov/burials-memorials/eligibility/",
+  "va-burial-in-national-cemetery.source.linkIsEnglish": "true",
   "va-burial-in-national-cemetery.summary": "Veterans, service members, and some family members may be eligible for burial in a VA national cemetery.",
   "va-burial-in-national-cemetery.eligibility.acceptableValues": "yes",
   "va-burial-in-national-cemetery.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-dependency-and-indemnity-compensation-child.json
+++ b/locales/en/benefits/va-dependency-and-indemnity-compensation-child.json
@@ -3,6 +3,7 @@
   "va-dependency-and-indemnity-compensation-child.headline": "Dependency and Indemnity Compensation (DIC) for Child",
   "va-dependency-and-indemnity-compensation-child.source.name": "U.S. Department of Veteran Affairs",
   "va-dependency-and-indemnity-compensation-child.source.link": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+  "va-dependency-and-indemnity-compensation-child.source.linkIsEnglish": "true",
   "va-dependency-and-indemnity-compensation-child.summary": "Tax-free financial assistance may be available to surviving family members of a service member or a veteran.",
   "va-dependency-and-indemnity-compensation-child.eligibility.acceptableValues": "yes",
   "va-dependency-and-indemnity-compensation-child.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-dependency-and-indemnity-compensation-parent.json
+++ b/locales/en/benefits/va-dependency-and-indemnity-compensation-parent.json
@@ -3,6 +3,7 @@
   "va-dependency-and-indemnity-compensation-parent.headline": "Dependency and Indemnity Compensation (DIC) for Parent",
   "va-dependency-and-indemnity-compensation-parent.source.name": "U.S. Department of Veteran Affairs",
   "va-dependency-and-indemnity-compensation-parent.source.link": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+  "va-dependency-and-indemnity-compensation-parent.source.linkIsEnglish": "true",
   "va-dependency-and-indemnity-compensation-parent.summary": "Tax-free financial assistance may be available to surviving family members of a service member or a veteran.",
   "va-dependency-and-indemnity-compensation-parent.eligibility.acceptableValues": "yes",
   "va-dependency-and-indemnity-compensation-parent.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-dependency-and-indemnity-compensation-spouse.json
+++ b/locales/en/benefits/va-dependency-and-indemnity-compensation-spouse.json
@@ -3,6 +3,7 @@
   "va-dependency-and-indemnity-compensation-spouse.headline": "Dependency and Indemnity Compensation (DIC) for Spouse",
   "va-dependency-and-indemnity-compensation-spouse.source.name": "U.S. Department of Veteran Affairs",
   "va-dependency-and-indemnity-compensation-spouse.source.link": "https://www.va.gov/disability/dependency-indemnity-compensation/",
+  "va-dependency-and-indemnity-compensation-spouse.source.linkIsEnglish": "true",
   "va-dependency-and-indemnity-compensation-spouse.summary": "Tax-free financial assistance may be available to surviving family members of a service member or a veteran.",
   "va-dependency-and-indemnity-compensation-spouse.eligibility.acceptableValues": "yes",
   "va-dependency-and-indemnity-compensation-spouse.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-education-benefits-for-survivors.json
+++ b/locales/en/benefits/va-education-benefits-for-survivors.json
@@ -3,6 +3,7 @@
   "va-education-benefits-for-survivors.headline": "Education Benefits (GI Bill) for Survivors",
   "va-education-benefits-for-survivors.source.name": "U.S. Department of Veteran Affairs",
   "va-education-benefits-for-survivors.source.link": "https://www.va.gov/education/survivor-dependent-benefits/",
+  "va-education-benefits-for-survivors.source.linkIsEnglish": "true",
   "va-education-benefits-for-survivors.summary": "VA education benefits (also called Chapter 35 benefits) or job training through a GI Bill program may be available for dependents and survivors of a veteran.",
   "va-education-benefits-for-survivors.eligibility.acceptableValues": "yes",
   "va-education-benefits-for-survivors.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-headstone-grave-marker.json
+++ b/locales/en/benefits/va-headstone-grave-marker.json
@@ -3,6 +3,7 @@
   "va-headstone-grave-marker.headline": "Veteran's Headstone and Grave Marker",
   "va-headstone-grave-marker.source.name": "U.S. Department of Veteran Affairs",
   "va-headstone-grave-marker.source.link": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+  "va-headstone-grave-marker.source.linkIsEnglish": "true",
   "va-headstone-grave-marker.summary": "A headstone, grave marker, or niche marker may be available to honor a veteran, service member, or eligible family member.",
   "va-headstone-grave-marker.eligibility.acceptableValues": "yes",
   "va-headstone-grave-marker.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-health-care-program-for-surviving-child.json
+++ b/locales/en/benefits/va-health-care-program-for-surviving-child.json
@@ -3,6 +3,7 @@
   "va-health-care-program-for-surviving-child.headline": "Civilian Health and Medical Program of the VA (CHAMPVA) for Child",
   "va-health-care-program-for-surviving-child.source.name": "U.S. Department of Veteran Affairs",
   "va-health-care-program-for-surviving-child.source.link": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
+  "va-health-care-program-for-surviving-child.source.linkIsEnglish": "true",
   "va-health-care-program-for-surviving-child.summary": "As a surviving child of a veteran you may be eligible for health insurance that covers the cost of some of your health care services and supplies, including prescription medicines.",
   "va-health-care-program-for-surviving-child.eligibility.acceptableValues": "yes",
   "va-health-care-program-for-surviving-child.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-health-care-program-for-surviving-spouse.json
+++ b/locales/en/benefits/va-health-care-program-for-surviving-spouse.json
@@ -3,6 +3,7 @@
   "va-health-care-program-for-surviving-spouse.headline": "Civilian Health and Medical Program of the VA (CHAMPVA) for Spouse",
   "va-health-care-program-for-surviving-spouse.source.name": "U.S. Department of Veteran Affairs",
   "va-health-care-program-for-surviving-spouse.source.link": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
+  "va-health-care-program-for-surviving-spouse.source.linkIsEnglish": "true",
   "va-health-care-program-for-surviving-spouse.summary": "As a surviving spouse of a veteran you may be eligible for health insurance that covers the cost of some of your health care services and supplies, including prescription medicines.",
   "va-health-care-program-for-surviving-spouse.eligibility.acceptableValues": "yes",
   "va-health-care-program-for-surviving-spouse.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-home-loan-program-for-survivors.json
+++ b/locales/en/benefits/va-home-loan-program-for-survivors.json
@@ -3,6 +3,7 @@
   "va-home-loan-program-for-survivors.headline": "Home Loan Program for Survivors",
   "va-home-loan-program-for-survivors.source.name": "U.S. Department of Veteran Affairs",
   "va-home-loan-program-for-survivors.source.link": "https://www.va.gov/housing-assistance/home-loans/surviving-spouse/",
+  "va-home-loan-program-for-survivors.source.linkIsEnglish": "true",
   "va-home-loan-program-for-survivors.summary": "A VA-backed home loan may be available to the surviving spouse of a veteran.",
   "va-home-loan-program-for-survivors.eligibility.acceptableValues": "yes",
   "va-home-loan-program-for-survivors.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-life-insurance-for-survivors.json
+++ b/locales/en/benefits/va-life-insurance-for-survivors.json
@@ -3,6 +3,7 @@
   "va-life-insurance-for-survivors.headline": "Veteran's Life Insurance for Surviving Beneficiaries",
   "va-life-insurance-for-survivors.source.name": "U.S. Department of Veteran Affairs",
   "va-life-insurance-for-survivors.source.link": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp",
+  "va-life-insurance-for-survivors.source.linkIsEnglish": "true",
   "va-life-insurance-for-survivors.summary": "Financial payment from a veteran's or service member's life insurance policy may be available.",
   "va-life-insurance-for-survivors.eligibility.acceptableValues": "yes",
   "va-life-insurance-for-survivors.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-medallion.json
+++ b/locales/en/benefits/va-medallion.json
@@ -3,6 +3,7 @@
   "va-medallion.headline": "Veteran's Medallion",
   "va-medallion.source.name": "U.S. Department of Veteran Affairs",
   "va-medallion.source.link": "https://www.va.gov/burials-memorials/memorial-items/headstones-markers-medallions/",
+  "va-medallion.source.linkIsEnglish": "true",
   "va-medallion.summary": "Some veterans who are buried in a private cemetery, including veterans of the National Guard, may be eligible for a headstone medallion.",
   "va-medallion.eligibility.acceptableValues": "yes",
   "va-medallion.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-presidential-memorial-certificate.json
+++ b/locales/en/benefits/va-presidential-memorial-certificate.json
@@ -3,6 +3,7 @@
   "va-presidential-memorial-certificate.headline": "Presidential Memorial Certificate",
   "va-presidential-memorial-certificate.source.name": "U.S. Department of Veteran Affairs",
   "va-presidential-memorial-certificate.source.link": "https://www.va.gov/burials-memorials/memorial-items/presidential-memorial-certificates/",
+  "va-presidential-memorial-certificate.source.linkIsEnglish": "true",
   "va-presidential-memorial-certificate.summary": "A Presidential Memorial Certificate (PMC) is an engraved paper certificate signed by the current president issued to honor the military service of a veteran or reservist.",
   "va-presidential-memorial-certificate.eligibility.acceptableValues": "yes",
   "va-presidential-memorial-certificate.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-survivor-pension-child-disabled.json
+++ b/locales/en/benefits/va-survivor-pension-child-disabled.json
@@ -3,6 +3,7 @@
   "va-survivor-pension-child-disabled.headline": "Survivor Pension for Child with Disabilities",
   "va-survivor-pension-child-disabled.source.name": "U.S. Department of Veteran Affairs",
   "va-survivor-pension-child-disabled.source.link": "https://www.va.gov/pension/survivors-pension/",
+  "va-survivor-pension-child-disabled.source.linkIsEnglish": "true",
   "va-survivor-pension-child-disabled.summary": "Monthly payments may be available to qualified surviving dependent children of wartime veterans who meet certain income and net worth limits.",
   "va-survivor-pension-child-disabled.eligibility.acceptableValues": "yes",
   "va-survivor-pension-child-disabled.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-survivor-pension-child.json
+++ b/locales/en/benefits/va-survivor-pension-child.json
@@ -3,6 +3,7 @@
   "va-survivor-pension-child.headline": "Survivor Pension for Child",
   "va-survivor-pension-child.source.name": "U.S. Department of Veteran Affairs",
   "va-survivor-pension-child.source.link": "https://www.va.gov/pension/survivors-pension/",
+  "va-survivor-pension-child.source.linkIsEnglish": "true",
   "va-survivor-pension-child.summary": "Monthly payments may be available to qualified surviving dependent children of wartime veterans who meet certain income and net worth limits.",
   "va-survivor-pension-child.eligibility.acceptableValues": "yes",
   "va-survivor-pension-child.eligibility.label": "The deceased served in the active military, naval, or air service.",

--- a/locales/en/benefits/va-survivor-pension-spouse.json
+++ b/locales/en/benefits/va-survivor-pension-spouse.json
@@ -3,6 +3,7 @@
   "va-survivor-pension-spouse.headline": "Survivor Pension for Spouse",
   "va-survivor-pension-spouse.source.name": "U.S. Department of Veteran Affairs",
   "va-survivor-pension-spouse.source.link": "https://www.va.gov/pension/survivors-pension/",
+  "va-survivor-pension-spouse.source.linkIsEnglish": "true",
   "va-survivor-pension-spouse.summary": "Monthly payments may be available to qualified surviving spouses of wartime veterans who meet certain income and net worth limits.",
   "va-survivor-pension-spouse.eligibility.acceptableValues": "yes",
   "va-survivor-pension-spouse.eligibility.label": "The deceased served in the active military, naval, or air service.",


### PR DESCRIPTION
## PR Summary

Fix issue #654 [Bug] Cannot translate the value of keypath Warning.

## Related Github Issue

- fixes #654

## Type of change

Please delete options that are not relevant.

- [ ] Task
- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Branch Name

654-keypath-warning

## Testing environment

To be tested on local dev environment.

## Detailed Testing steps

Test locally
1. pull this branch locally
2. run npm run dev in terminal
3. check no keypath warning like following
WARN  [vue-i18n] Value of key 'dod-burial-benefits.source.linkIsEnglish' is not a string or function !
WARN  [vue-i18n] Cannot translate the value of keypath 'dod-burial-benefits.source.linkIsEnglish'. Use the value of keypath as  default.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
