### PR TITLE
#701 - [bug] cspell-error-ensure-top-level-permissions-are-not-set-to-write-all

### DIFF
--- a/.github/workflows/check_spelling.yml
+++ b/.github/workflows/check_spelling.yml
@@ -7,9 +7,7 @@ on:
       - content/**
       - multi-life-event-2023**
 
-  pull_request:
-    branches:
-      - main
+permissions: read-all
 
 jobs:
   check_spelling:


### PR DESCRIPTION
## PR Summary

## Related Github Issue

- fixes #701 

## Type of change

- [ ] Bug fix

## Branch Name

The name of this branch: bug/701-bug-cspell-error-ensure-top-level-permissions-are-not-set-to-write-all

## Detailed Testing steps

Link to testing steps in the issue or list them here:
Please run `Megalinter` Action manually and see if `Megalinter` step produces `Linted [REPOSITORY] files with [checkov] successfully` success message.

## Checklist:

- [ ] My changes generate no new warnings
