### PR TITLE
#762 Remove critical application field for benefit ticket to work

### DIFF
--- a/content/benefits/ssa-ticket-to-work.md
+++ b/content/benefits/ssa-ticket-to-work.md
@@ -12,7 +12,6 @@ source:
   isEnglish: ssa-ticket-to-work.source.linkIsEnglish
 
 summary: ssa-ticket-to-work.summary
-criticalApplicationInformation: ssa-ticket-to-work.criticalApplicationInformation
 
 eligibility:
   # In the order you want the criteria to display, list criteriaKeys from the csv here, each followed by a comma-separated list of which values indicate eligibility for that criteria. Wrap individual values in quotes if they have inner commas.


### PR DESCRIPTION
## PR Summary

Remove critical application information field for benefit ticket to work program.

## Related Github Issue

- fixes #762

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## Branch Name

762-ticket-to-work

## Testing environment

[Link to a Federalist URL or to be tested on local dev environment.](https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/762-ticket-to-work

## Detailed Testing steps

Link to testing steps in the issue or list them here:

1. Navigate to https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/762-ticket-to-work/disability/?
2. Check benefit "Ticket to work program" critical application information field removed.
3. Click Español to navigate to https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/762-ticket-to-work/es/disability/?
4. Check benefit "Boleto para trabajar" critical application information field removed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
