### PR TITLE
761 update tab color

### DIFF
--- a/assets/styles/theme/_uswds-theme-general.scss
+++ b/assets/styles/theme/_uswds-theme-general.scss
@@ -103,7 +103,7 @@ Focus styles
 ----------------------------------------
 */
 
-$theme-focus-color: "blue-40v";
+$theme-focus-color: "orange-50v";
 $theme-focus-offset: 0;
 $theme-focus-style: solid;
 $theme-focus-width: 0.5;

--- a/assets/styles/theme/_uswds-theme-usagov.scss
+++ b/assets/styles/theme/_uswds-theme-usagov.scss
@@ -92,13 +92,6 @@ $AZ-button-disabled: #859cba;
   width: inherit;
   height: inherit;
 
-  &:focus {
-    @include u-outline("black");
-    background-color: transparent;
-    outline-width: units(1px);
-    outline-offset: units(1px);
-  }
-
   &:hover {
     @include u-border(1px, "solid", "black");
     background-color: transparent;


### PR DESCRIPTION
## PR Summary

updates focus color to better match usa.gov

## Related Github Issue

- #761 

## Type of change

Please delete options that are not relevant.

- [ ] Task
- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Branch Name

761-update-tab-color

## Testing environment

[Link to a Federalist URL or to be tested on local dev environment.](https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/761-update-tab-color/death-of-a-loved-one/)

## Detailed Testing steps
navigate to feature branch test env, tab through site to activate `:focus` state
- [ ] focus on elements should match usa.gov using #c05600

etc...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
