### PR TITLE
Fix animate scroll to top

### DIFF
--- a/components/BetaUsaGovFooter.vue
+++ b/components/BetaUsaGovFooter.vue
@@ -9,6 +9,7 @@
           href="#"
           title="Back to top"
           class="stuck"
+          :class="{ show: isHidden }"
           :style="backgroundImageStyle"
           @click.prevent="scrollToTop">
           {{ $t("returnToTop") }}
@@ -19,6 +20,7 @@
           href="#"
           title="Subir a la parte superior"
           class="stuck"
+          :class="{ show: isHidden }"
           :style="backgroundImageStyle"
           @click.prevent="scrollToTop">
           {{ $t("returnToTop") }}
@@ -92,7 +94,11 @@ import sanitizeUrl from "~/mixins/SanitizeBears"
 export default {
   name: "BetaUsaGovFooter",
   mixins: [sanitizeUrl],
-
+  data() {
+    return{
+      isHidden: true
+    }
+  },
   computed: {
     backgroundImageStyle() {
       const image = require("@/assets/img-custom/Icon_Back_to_Top_Blue.png")
@@ -101,7 +107,12 @@ export default {
       }
     },
   },
-
+  mounted () {
+    window.addEventListener('scroll', this.toggleScrollToTop);
+  },
+  unmounted () {
+    window.removeEventListener('scroll', this.toggleScrollToTop);
+  },
   methods: {
     sanitizedBearsUrl(benefitUrl, defaultValue = "#") {
       if (benefitUrl && benefitUrl.length > 0) {
@@ -110,10 +121,13 @@ export default {
         return defaultValue
       }
     },
+    toggleScrollToTop() {
+      this.isHidden = document.documentElement.scrollTop < window.innerHeight
+    },
     scrollToTop() {
       window.scrollTo(0, 0)
     },
-  },
+  }
 }
 </script>
 
@@ -134,8 +148,24 @@ export default {
   line-height: 50px;
   display: inline-block;
   text-align: center;
-  z-index: 1
+  z-index: 1;
+  /* This timing applies on the way OUT */
+  transition-timing-function: ease-in;
+  /* Quick on the way out */
+  transition: 0.25s;
+  /* Hide thing by pushing it outside by default */
+  transform: translateX(0);
 }
+
+#back-to-top.show {
+  /* This timing applies on the way IN */
+  transition-timing-function: ease-out;
+  /* A litttttle slower on the way in */
+  transition: 0.3s;
+  /* Move into place */
+  transform: translateX(130%);
+}
+
 #back-to-top.stuck {
   right: 0;
   white-space: nowrap


### PR DESCRIPTION
## PR Summary

includes an animation of our scroll to top interactive if the `scrollTop` value is greater than the `window.innerHeight`

## Related Github Issue

- updates #767

## Type of change

## Branch Name

[fix-animate-scroll-to-top](https://github.com/GSA/usagov-benefits-eligibility/tree/fix-animate-scroll-to-top)

## Testing environment

https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/fix-animate-scroll-to-top/death-of-a-loved-one/

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] visit federalist, scroll to top element should be hidden
- [x] scroll down, scroll to element should appear
- [x] when clicking the scroll to element it should bring you to the top and be hidden

etc...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
