### PR TITLE
Updated es phone links

### DIFF
--- a/components/UsaGovFooter.vue
+++ b/components/UsaGovFooter.vue
@@ -59,7 +59,7 @@
                 <address class="usa-footer__address">
                   <div class="usa-footer__contact-info">
                     <a
-                      :href="sanitizedBearsUrl($t('footer.GroupOne.linkOneUrl'))">
+                      :href="sanitizedBearsUrl($t('footer.GroupTwo.linkOneUrl'))">
                       {{ $t("footer.GroupTwo.linkOne") }}
                     </a>
                   </div>

--- a/locales/es/es.json
+++ b/locales/es/es.json
@@ -170,7 +170,7 @@
       "header": "Centro de llamadas de USAGov",
       "subHeader": "Haga una pregunta a USAGov en Español al",
       "linkOne": "1-844-USAGOV1 (1-844-872-4681)",
-      "linkOneUrl": "https://www.usa.gov/es/centro-de-llamadas",
+      "linkOneUrl": "https://www.usa.gov/es/llamenos",
       "linkTwo": "In English",
       "linkTwoUrl": "https://www.usa.gov/contact"
     },
@@ -329,7 +329,7 @@
       ],
       "secondaryNav": {
         "linkOneText": "Llámenos al 1-844-USAGOV1",
-        "linkOneUrl": "https://www.usa.gov/es/centro-de-llamadas"
+        "linkOneUrl": "https://www.usa.gov/es/llamenos"
       },
       "form": {
         "label": "Buscar",


### PR DESCRIPTION
## PR Summary

On the Espańol version of all life events, (e.g. https://benefits-tool.usa.gov/es/disability) in the header, the phone number link points to https://www.usa.gov/es/centro-de-llamadas, which redirects to https://www.usa.gov/es/llamenos

In the footer, the phone number link points to https://www.usa.gov/espanol/acerca-de-usagov-en-espanol

Both links should point to https://www.usa.gov/es/llamenos

## Related Github Issue

- fixes #788

## Type of change

Please delete options that are not relevant.

- [ ] Task
- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] check phone links across benefits to ensure that the Spanish translation sets them as `https://www.usa.gov/es/llamenos`

etc...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
