### PR TITLE
828 remove critical info ssi

### DIFF
--- a/content/benefits/ssa-supplemental-security-income-child.md
+++ b/content/benefits/ssa-supplemental-security-income-child.md
@@ -12,7 +12,6 @@ source:
   isEnglish: ssa-supplemental-security-income-child.source.linkIsEnglish
 
 summary: ssa-supplemental-security-income-child.summary
-criticalApplicationInformation: ssa-supplemental-security-income-child.criticalApplicationInformation
 
 eligibility:
   # In the order you want the criteria to display, list criteriaKeys from the csv here, each followed by a comma-separated list of which values indicate eligibility for that criteria. Wrap individual values in quotes if they have inner commas.

--- a/content/benefits/ssa-supplemental-security-income-elder.md
+++ b/content/benefits/ssa-supplemental-security-income-elder.md
@@ -12,7 +12,6 @@ source:
   isEnglish: ssa-supplemental-security-income-elder.source.linkIsEnglish
 
 summary: ssa-supplemental-security-income-elder.summary
-criticalApplicationInformation: ssa-supplemental-security-income-elder.criticalApplicationInformation
 
 eligibility:
   # In the order you want the criteria to display, list criteriaKeys from the csv here, each followed by a comma-separated list of which values indicate eligibility for that criteria. Wrap individual values in quotes if they have inner commas.

--- a/content/benefits/ssa-supplemental-security-income_adult.md
+++ b/content/benefits/ssa-supplemental-security-income_adult.md
@@ -12,7 +12,6 @@ source:
   isEnglish: ssa-supplemental-security-income_adult.source.linkIsEnglish
 
 summary: ssa-supplemental-security-income_adult.summary
-criticalApplicationInformation: ssa-supplemental-security-income_adult.criticalApplicationInformation
 
 eligibility:
   # In the order you want the criteria to display, list criteriaKeys from the csv here, each followed by a comma-separated list of which values indicate eligibility for that criteria. Wrap individual values in quotes if they have inner commas.

--- a/locales/en/benefits/ssa-supplemental-security-income-child.json
+++ b/locales/en/benefits/ssa-supplemental-security-income-child.json
@@ -4,6 +4,5 @@
   "ssa-supplemental-security-income-child.source.name": "Social Security Administration",
   "ssa-supplemental-security-income-child.source.link": "https://www.ssa.gov/benefits/disability/apply-child.html",
   "ssa-supplemental-security-income-child.summary": "SSI provides monthly cash payments to help meet the basic needs of children who have a disability. If you care for a child or teenager with a disability, and have limited income and savings or other resources, your child may be eligible for SSI.",
-  "ssa-supplemental-security-income-child.criticalApplicationInformation": "Only one application is needed to apply for all the benefits offered by SSA.",
   "ssa-supplemental-security-income-child.eligibility.label": "You are under 18 years old."
 }

--- a/locales/en/benefits/ssa-supplemental-security-income-elder.json
+++ b/locales/en/benefits/ssa-supplemental-security-income-elder.json
@@ -4,6 +4,5 @@
   "ssa-supplemental-security-income-elder.source.name": "Social Security Administration",
   "ssa-supplemental-security-income-elder.source.link": "https://www.ssa.gov/benefits/ssi/65older.html",
   "ssa-supplemental-security-income-elder.summary": "Supplemental Security Income (SSI) provides financial assistance to older, blind, and people with disabilities to help meet basic needs for food, clothing, and shelter.",
-  "ssa-supplemental-security-income-elder.criticalApplicationInformation": "Only one application is needed to apply for all the benefits offered by SSA.",
   "ssa-supplemental-security-income-elder.eligibility.label": "You are at least 65 years old."
 }

--- a/locales/en/benefits/ssa-supplemental-security-income_adult.json
+++ b/locales/en/benefits/ssa-supplemental-security-income_adult.json
@@ -4,6 +4,5 @@
   "ssa-supplemental-security-income_adult.source.name": "Social Security Administration",
   "ssa-supplemental-security-income_adult.source.link": "https://www.ssa.gov/benefits/ssi/adults.html",
   "ssa-supplemental-security-income_adult.summary": "Supplemental Security Income (SSI) provides financial assistance to adults and children with a disability, and people 65 and older without disabilities who meet specific financial limits.",
-  "ssa-supplemental-security-income_adult.criticalApplicationInformation": "Only one application is needed to apply for all the benefits offered by SSA.",
   "ssa-supplemental-security-income_adult.eligibility.label": "You are 18 to 64 years old."
 }

--- a/locales/es/benefits/ssa-supplemental-security-income-child.json
+++ b/locales/es/benefits/ssa-supplemental-security-income-child.json
@@ -4,6 +4,5 @@
   "ssa-supplemental-security-income-child.source.name": "Administración del Seguro Social (SSA)",
   "ssa-supplemental-security-income-child.source.link": "https://www.ssa.gov/benefits/disability/apply-child.html",
   "ssa-supplemental-security-income-child.summary": "El programa de Seguridad de ingreso suplementario (SSI, sigla en inglés) provee pagos mensuales en efectivo para ayudar a cubrir las necesidades básicas de niñas/os con discapacidades. Si usted cuida a una niña/o o adolescente que tiene una discapacidad, y tiene ingresos u otros recursos limitados, su niña/o podría tener derecho a SSI para los beneficios administrados por la Administración del Seguro Social.",
-  "ssa-supplemental-security-income-child.criticalApplicationInformation": "Presente una sola solicitud y será considerado para todos los beneficios ofrecidos por el Seguro Social (SSA).",
   "ssa-supplemental-security-income-child.eligibility.label": "Usted es menor de 18 años."
 }

--- a/locales/es/benefits/ssa-supplemental-security-income-elder.json
+++ b/locales/es/benefits/ssa-supplemental-security-income-elder.json
@@ -4,6 +4,5 @@
   "ssa-supplemental-security-income-elder.source.name": "Administración del Seguro Social (SSA)",
   "ssa-supplemental-security-income-elder.source.link": "https://www.ssa.gov/benefits/ssi/65older.html",
   "ssa-supplemental-security-income-elder.summary": "El Programa de seguridad de ingreso suplementario (SSI, sigla en inglés) brinda asistencia financiera a personas mayores, personas ciegas o personas con discapacidades para ayudarles a cumplir con sus necesidades básicas de alimentos, ropa y vivienda.",
-  "ssa-supplemental-security-income-elder.criticalApplicationInformation": "Presente una sola solicitud y será considerado para todos los beneficios ofrecidos por el Seguro Social (SSA).",
   "ssa-supplemental-security-income-elder.eligibility.label": "Usted tiene al menos 65 años."
 }

--- a/locales/es/benefits/ssa-supplemental-security-income_adult.json
+++ b/locales/es/benefits/ssa-supplemental-security-income_adult.json
@@ -4,6 +4,5 @@
   "ssa-supplemental-security-income_adult.source.name": "Administración del Seguro Social (SSA)",
   "ssa-supplemental-security-income_adult.source.link": "https://www.ssa.gov/espanol/beneficios/ssi/adultos.html",
   "ssa-supplemental-security-income_adult.summary": "El programa de Seguridad de ingreso suplementario (SSI, sigla en inglés) brinda asistencia financiera a adultos y niños con discapacidades, y a personas mayores de 65 años sin discapacidades que cumplen con límites financieros específicos.",
-  "ssa-supplemental-security-income_adult.criticalApplicationInformation": "Presente una sola solicitud y será considerado para todos los beneficios ofrecidos por el Seguro Social (SSA).",
   "ssa-supplemental-security-income_adult.eligibility.label": "Usted tiene entre 18 y 64 años."
 }


### PR DESCRIPTION
## PR Summary

Removed the critical info application field for three benefits - ready for QA: 

Locales Folder
ES:
1. locales/es/benefits/ssa-supplemental-security-income-child.json
2. locales/es/benefits/ssa-supplemental-security-income-elder.json
3. locales/es/benefits/ssa-supplemental-security-income_adult.json
EN:
1. locales/en/benefits/ssa-supplemental-security-income-child.json
2. locales/en/benefits/ssa-supplemental-security-income-elder.json
3. locales/en/benefits/ssa-supplemental-security-income_adult.json

Content Folder:
1. content/benefits/ssa-supplemental-security-income-child.md
2. content/benefits/ssa-supplemental-security-income-elder.md
3. content/benefits/ssa-supplemental-security-income_adult.md

## Related Github Issue

- fixes #828 

## Type of change

Please delete options that are not relevant.

- [ ] Content Change

## Branch Name

828-remove-critical-info-SSI

## Testing environment

https://federalist-edd11e6f-8be2-4dc2-a85e-1782e0bcb08e.sites.pages.cloud.gov/preview/gsa/usagov-benefits-eligibility/828-remove-critical-info-SSI/es/disability/?

## Detailed Testing steps

Need QA testing as needed.
- [ ] Testing step 1
- [ ] Testing step 2
- [ ] Testing step 3

etc...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
