### PR TITLE
Bug/cypress test failing prod release

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           SITE_PREFIX: ${{ secrets.SITE_PREFIX }}
         run: |
-          if ${{ github.head_ref || github.ref_name }} = "prod"; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool.usa.gov/',#" cypress.config.js; elif ${{ github.head_ref || github.ref_name }} = "release"; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool-demo.usa.gov/',#" cypress.config.js; else sed -i "s#^    baseUrl: .*#    baseUrl: '${SITE_PREFIX}${{ github.head_ref || github.ref_name }}',#" cypress.config.js; fi
+          if ${{ github.head_ref || github.ref_name }} == "prod"; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool.usa.gov/',#" cypress.config.js; elif ${{ github.head_ref || github.ref_name }} == "release"; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool-demo.usa.gov/',#" cypress.config.js; else sed -i "s#^    baseUrl: .*#    baseUrl: '${SITE_PREFIX}${{ github.head_ref || github.ref_name }}',#" cypress.config.js; fi
 
       - name: Test if cypress config file is configured correctly
         run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           SITE_PREFIX: ${{ secrets.SITE_PREFIX }}
         run: |
-          if ${{ github.head_ref || github.ref_name }} == "prod"; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool.usa.gov/',#" cypress.config.js; elif ${{ github.head_ref || github.ref_name }} == "release"; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool-demo.usa.gov/',#" cypress.config.js; else sed -i "s#^    baseUrl: .*#    baseUrl: '${SITE_PREFIX}${{ github.head_ref || github.ref_name }}',#" cypress.config.js; fi
+          if [[ ${{ github.head_ref || github.ref_name }} == "prod" ]]; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool.usa.gov/',#" cypress.config.js; elif [[ ${{ github.head_ref || github.ref_name }} == "release" ]]; then sed -i "s#^    baseUrl: .*#    baseUrl: 'https://benefits-tool-demo.usa.gov/',#" cypress.config.js; else sed -i "s#^    baseUrl: .*#    baseUrl: '${SITE_PREFIX}${{ github.head_ref || github.ref_name }}',#" cypress.config.js; fi
 
       - name: Test if cypress config file is configured correctly
         run: |


### PR DESCRIPTION
## PR Summary

This PR fixes the issue identified here in this ticket:
[Cypress Tests failing in Release and Prod#865](https://github.com/GSA/usagov-benefits-eligibility/issues/865)

It fixes the problem with the Cypress Workflow file where the target URL needs to be updated depending on the branch it's being run against.
