### PR TITLE
add open all and close all cypress tests

### DIFF
--- a/cypress/e2e/ui/open-all-close-all-button.cy.js
+++ b/cypress/e2e/ui/open-all-close-all-button.cy.js
@@ -1,0 +1,29 @@
+/// <reference types="cypress"/>
+
+const sitePages = require("../../fixtures/site-pages.json")
+
+describe('Validate Open All button functionality', ()=> {
+    sitePages.forEach(sitePage => {
+        it(`Verify Open All button should open all accordion cards in ${sitePage.name}`, ()=> {
+            cy.visit({ url: sitePage.route })
+            cy.get('.flex-row .open-all').click()
+            cy.get('.usa-accordion__heading .usa-accordion__button').each((accordion) => {
+                cy.wrap(accordion).invoke("prop", "ariaExpanded").should('eq', 'true')
+            })
+        })
+    });  
+})
+
+describe('Validate Close All button functionality', ()=> {
+    sitePages.forEach(sitePage => {
+        it(`Verify Close All button should close all accordion cards in ${sitePage.name}`, ()=> {
+            cy.visit({ url: sitePage.route })
+            cy.get('.flex-row .open-all').click()
+            cy.get('.flex-row .close-all').click()
+            cy.get('.usa-accordion__heading .usa-accordion__button').each((accordion) => {
+                cy.wrap(accordion).invoke("prop", "ariaExpanded").should('eq', 'false')
+            })
+        })
+        
+    });  
+})


### PR DESCRIPTION
## PR Summary

This PR adds Cypress automated tests for open all and close all functionality

## Related Github Issue

- fixes #(884)

## Type of change

- [ ] Task
- [ ] New feature

## Detailed Testing steps
- [ ] Pull branch
- [ ] start local
- [ ] run ```npm run cypress:run_chrome```
- [ ] Verify ```open-all-close-all-button.cy.js``` tests are passing

