### PR TITLE
add benefit sort tests by title and relevance for covid19 filter

### DIFF
--- a/cypress/e2e/ui/sort-benefits-list.cy.js
+++ b/cypress/e2e/ui/sort-benefits-list.cy.js
@@ -1,0 +1,54 @@
+/// <reference types="cypress"/>
+
+import { pages } from "../../support/page-objects/pages.js"
+import * as EN_CRITERIA from "../../../locales/en/criteria.json"
+import * as EN_BENEFITS_COVID_19 from "../../../locales/en/benefits/fema-covid-19-funeral-assistance.json"
+
+const criteriaEn = EN_CRITERIA
+const benefitsCovid19En = EN_BENEFITS_COVID_19
+
+
+describe("Sort benefits accordion list using Covid 19 filter", () => {
+    beforeEach(() => {
+        cy.visit("/")
+      })
+
+    it("Validate benefits are sorted by Relevance by default", ()=> {
+        pages.checkboxLabels().contains(criteriaEn["criteria.deceased_died_of_COVID.label"]).click()
+        const benefitsList = []
+        
+        pages.accordions().each(($el) => {
+            benefitsList.push($el.text().trim())
+        }).then(() => {
+            expect(benefitsList[0]).to.include(benefitsCovid19En["fema-covid-19-funeral-assistance.title"])
+        })
+    })
+
+    it("Validate benefits are sorted alphabetically when using benefit sorted by Title A-Z", ()=> {
+        pages.benefitSortDropDown().select("Title (A-Z)")
+        pages.checkboxLabels().contains(criteriaEn["criteria.deceased_died_of_COVID.label"]).click()
+        const benefitsList = []
+        const benefitsListSorted = []
+
+        pages.accordions().each(($el) => {
+            benefitsList.push($el.text().trim())
+            benefitsListSorted.push($el.text().trim())
+        }).then(() => {
+            expect(benefitsList).to.deep.equal(benefitsListSorted.sort())
+        })
+    })
+
+    it("Validate benefits are sorted by Relevance when user changes sort by Title A-Z to sort by Relevance", ()=> {
+        pages.benefitSortDropDown().select("Title (A-Z)")
+        pages.checkboxLabels().contains(criteriaEn["criteria.deceased_died_of_COVID.label"]).click()
+        pages.benefitSortDropDown().select("Relevance")
+        const benefitsList = []
+
+        pages.accordions().each(($el) => {
+            benefitsList.push($el.text().trim())
+        }).then(() => {
+            expect(benefitsList[0]).to.include(benefitsCovid19En["fema-covid-19-funeral-assistance.title"])
+        })
+    })
+
+})

--- a/cypress/support/page-objects/pages.js
+++ b/cypress/support/page-objects/pages.js
@@ -31,6 +31,9 @@ class Pages {
   checkboxLabels() {
     return cy.get(".usa-checkbox__label")
   }
+  benefitSortDropDown() {
+    return cy.get("select#benefitSort")
+  }
 }
 
 export const pages = new Pages()


### PR DESCRIPTION
## PR Summary

This PR adds adds Cypress automated tests to validate sort benefits by Title A-Z and Relevance using covid 19 filter.

## Related Github Issue

- https://github.com/GSA/usagov-benefits-eligibility/issues/886

## Type of change

- [ ] Task
- [ ] New feature

## Detailed Testing steps
User navigates to death of a loved one page and checks "The deceased died or likely died of COVID-19" checkbox label
The user then will apply benefits sort by Relevance and Title (A-Z)

The tests will be:-

- Validate benefits are sorted by Relevance by default
- Validate benefits are sorted alphabetically when using benefit sorted by Title A-Z
- Validate benefits are sorted by Relevance when user changes sort by Title A-Z to sort by Relevance

## Running the automated tests:
- [ ] Pull branch
- [ ] start local
- [ ] run ```npm run cypress:run_chrome```
- [ ] Verify ```sort-benefits-list.cy.js``` tests are passing

