### PR TITLE
add test that stub print my selections

### DIFF
--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -3,7 +3,7 @@
 import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 
-describe("Select ", () => {
+describe("Select criteria and print selections", () => {
   before(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -1,0 +1,19 @@
+/// <reference types="cypress"/>
+
+import { pages } from "../../support/page-objects/pages.js"
+import * as EN_CRITERIA from "../../../locales/en/criteria.json"
+
+describe("Select ", () => {
+    before(() => {
+        cy.visit("/")
+      })
+
+      it("Select a criteria and stub printing when user clicks Print My Selections", () => {
+        pages.checkboxLabels().contains(EN_CRITERIA["criteria.deceased_death_location_is_US.label"]).click()
+        cy.window().then(win => {
+            cy.stub(win, 'print').as('print')
+          });
+        pages.buttons().contains("Print my selections").click()
+         cy.get('@print').should('be.calledOnce')
+      })
+})

--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -4,16 +4,16 @@ import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 
 describe("Select ", () => {
-    before(() => {
-        cy.visit("/")
-      })
+  before(() => {
+    cy.visit("/")
+  })
 
-      it("Select a criteria and stub printing when user clicks Print My Selections", () => {
-        pages.checkboxLabels().contains(EN_CRITERIA["criteria.deceased_death_location_is_US.label"]).click()
-        cy.window().then(win => {
-            cy.stub(win, 'print').as('print')
-          });
-        pages.buttons().contains("Print my selections").click()
-         cy.get('@print').should('be.calledOnce')
-      })
+  it("Select a criteria and stub printing when user clicks Print My Selections", () => {
+    pages.checkboxLabels().contains(EN_CRITERIA["criteria.deceased_death_location_is_US.label"]).click()
+    cy.window().then((win) => {
+      cy.stub(win, "print").as("print")
+    })
+    pages.buttons().contains("Print my selections").click()
+    cy.get("@print").should("be.calledOnce")
+  })
 })

--- a/cypress/support/page-objects/pages.js
+++ b/cypress/support/page-objects/pages.js
@@ -67,6 +67,9 @@ class Pages {
   secondaryFooterSocialMedia() {
     return cy.get(".usa-footer__social-links .usa-social-link")
   }
+  buttons() {
+    return cy.get(".usa-button")
+  }
 }
 
 export const pages = new Pages()


### PR DESCRIPTION
## PR Summary

This PR adds cypress e2e automated test that validates when a user clicks “Print my Selections” button, print functionality is triggered. 

Given when we utilize cypress to trigger printing, a browser window pops up and the test will remain stuck until a user interacts with the window to close it, this test will stub the call to print and include an assertion to validate that printing was called once. 
To avoid opening print dialogue which makes the test stuck, we can stub the window.print method before the application calls it.

https://glebbahmutov.com/cypress-examples/recipes/stub-window-print.html#app-calls-the-window-print-method

## Related Github Issue

https://github.com/GSA/usagov-benefits-eligibility/issues/846

## Type of change

- [ ] Task
- [ ] New feature

## Detailed Testing steps

- Pull branch
- start local
- run ```npm run cypress:run_chrome```
- Verify ```print-selections.cy.js``` as well as other tests are passing

