### PR TITLE
Enable cache in the federalist.json

### DIFF
--- a/federalist.json
+++ b/federalist.json
@@ -20,6 +20,5 @@
         "cache-control": "public, max-age=60, must-revalidate"
       }
     }
-  ],
-  "cache": false
+  ]
 }


### PR DESCRIPTION
## PR Summary

This PR enables cache back again after the Pages Support team increased our container size and build failing issue has been resolved.

## Related Github Issue

- fixes #915 https://github.com/GSA/usagov-benefits-eligibility/issues/915

## Type of change

- [ ] Bug fix


