### PR TITLE
Add e2e to validate content on accordion cards

### DIFF
--- a/cypress/e2e/ui/ui-render-content.cy.js
+++ b/cypress/e2e/ui/ui-render-content.cy.js
@@ -2,6 +2,14 @@
 
 import { pages } from "../../support/page-objects/pages.js"
 import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
+import * as EN_SURVIVOR_BENEFITS_CHILD from "../../../locales/en/benefits/ssa-survivor-benefits-child.json"
+import * as ES_SURVIVOR_BENEFITS_PARENTS from "../../../locales/es/benefits/ssa-survivor-benefits-parents.json"
+import * as EN_CMS_MEDICARE_SAVINGS_PROGRAMS from "../../../locales/en/benefits/cms-medicare-savings-programs.json"
+import * as ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS from "../../../locales/es/benefits/dod-retirement-and-disability-payments.json"
+import * as EN_DOD_THRIFT_SAVINGS_PLAN from "../../../locales/en/benefits/dod-thrift-savings-plan.json"
+import * as ES_DOI_HOUSING_IMPROVEMENT_PROGRAM from "../../../locales/es/benefits/doi-housing-improvement-program.json"
+import * as EN_LIFE_EVENTS_DISABILITY from "../../../locales/en/life-events/disability.json"
+import * as EN_LIFE_EVENTS_RETIREMENT from "../../../locales/en/life-events/retirement.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
@@ -15,4 +23,73 @@ describe("Verify UI is rendering content correctly", () => {
       })
     })
   })
+})
+
+describe("Verify Benefits Card content is displaying correctly", ()=> {
+  beforeEach(() => {
+    cy.visit("/")
+  })
+  it("Verify content on Survivor Benefits for Child accordion is displaying correctly on DOLO English page", ()=> {
+    pages.accordions().contains(EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.title"]).click()
+    pages.survivorBenefitsChildCard().should("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.source.name"])
+    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.summary"])
+    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.criticalApplicationInformation"])
+    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.acceptableValues"])
+    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.label"])
+    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.acceptableValues1"])
+  })
+
+  it("Verify content on Beneficios para padre/madre sobreviviente accordion is displaying correctly on DOLO Spanish page", ()=> {
+    pages.languageSwitcher().click()
+    pages.accordions().contains(ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.title"]).click()
+    pages.survivorBenefitsParentCard().should("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.source.name"])
+    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.summary"])
+    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.criticalApplicationInformation"])
+    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.eligibility.acceptableValues"])
+    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.eligibility.label"])
+  })
+
+  it("Verify content on Medicare Savings Programs (MSP) accordion is displaying correctly on Disability English page", ()=> {
+    pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_DISABILITY["disability.title"]).click()
+    pages.accordions().contains(EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.title"]).click()
+    pages.medicareSavingsProgramsCard().should("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.source.name"])
+    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.summary"])
+    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.criticalApplicationInformation"])
+    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.eligibility.label"])
+    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.source.link"])
+  })
+
+  it("Verify content on Pagos Concurrentes de Jubilación y de Discapacidad (CRDP) accordion is displaying correctly on Disability Spanish page", ()=> {
+    pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_DISABILITY["disability.title"]).click()
+    pages.languageSwitcher().click()
+    pages.accordions().contains(ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.title"]).click()
+    pages.retirementAndDisabilityPaymentsCard().should("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.source.name"])
+    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.summary"])
+    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.criticalApplicationInformation"])
+    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.label"])
+    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.label1"])
+    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.acceptableValues1"])
+    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.acceptableValues2"])
+  })
+
+  it("Verify content on Thrift Savings Plan (TSP) accordion is displaying correctly on Retirement English page", ()=> {
+    pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_RETIREMENT["retirement.title"]).click()
+    pages.accordions().contains(EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.title"]).click()
+    pages.thriftSavingsPlanCard().should("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.source.name"])
+    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.summary"])
+    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.criticalApplicationInformation"])
+    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.eligibility.label"])
+    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.source.link"])
+  })
+
+  it("Verify content on Programa de mejoramiento de vivienda (HIP) accordion is displaying correctly on Retirement Spanish page", ()=> {
+    pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_RETIREMENT["retirement.title"]).click()
+    pages.languageSwitcher().click()
+    pages.accordions().contains(ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.title"]).click()
+    pages.housingImprovementProgramCard().should("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.source.name"])
+    .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.summary"])
+    .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.eligibility.label"])
+    .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.source.link"])
+  })
+
 })

--- a/cypress/e2e/ui/ui-render-content.cy.js
+++ b/cypress/e2e/ui/ui-render-content.cy.js
@@ -25,71 +25,109 @@ describe("Verify UI is rendering content correctly", () => {
   })
 })
 
-describe("Verify Benefits Card content is displaying correctly", ()=> {
+describe("Verify Benefits Card content is displaying correctly", () => {
   beforeEach(() => {
     cy.visit("/")
   })
-  it("Verify content on Survivor Benefits for Child accordion is displaying correctly on DOLO English page", ()=> {
+  it("Verify content on Survivor Benefits for Child accordion is displaying correctly on DOLO English page", () => {
     pages.accordions().contains(EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.title"]).click()
-    pages.survivorBenefitsChildCard().should("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.source.name"])
-    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.summary"])
-    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.criticalApplicationInformation"])
-    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.acceptableValues"])
-    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.label"])
-    .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.acceptableValues1"])
+    pages
+      .survivorBenefitsChildCard()
+      .should("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.source.name"])
+      .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.summary"])
+      .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.criticalApplicationInformation"])
+      .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.acceptableValues"])
+      .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.label"])
+      .and("contain", EN_SURVIVOR_BENEFITS_CHILD["ssa-survivor-benefits-child.eligibility.acceptableValues1"])
   })
 
-  it("Verify content on Beneficios para padre/madre sobreviviente accordion is displaying correctly on DOLO Spanish page", ()=> {
+  it("Verify content on Beneficios para padre/madre sobreviviente accordion is displaying correctly on DOLO Spanish page", () => {
     pages.languageSwitcher().click()
     pages.accordions().contains(ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.title"]).click()
-    pages.survivorBenefitsParentCard().should("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.source.name"])
-    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.summary"])
-    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.criticalApplicationInformation"])
-    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.eligibility.acceptableValues"])
-    .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.eligibility.label"])
+    pages
+      .survivorBenefitsParentCard()
+      .should("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.source.name"])
+      .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.summary"])
+      .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.criticalApplicationInformation"])
+      .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.eligibility.acceptableValues"])
+      .and("contain", ES_SURVIVOR_BENEFITS_PARENTS["ssa-survivor-benefits-parents.eligibility.label"])
   })
 
-  it("Verify content on Medicare Savings Programs (MSP) accordion is displaying correctly on Disability English page", ()=> {
+  it("Verify content on Medicare Savings Programs (MSP) accordion is displaying correctly on Disability English page", () => {
     pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_DISABILITY["disability.title"]).click()
     pages.accordions().contains(EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.title"]).click()
-    pages.medicareSavingsProgramsCard().should("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.source.name"])
-    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.summary"])
-    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.criticalApplicationInformation"])
-    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.eligibility.label"])
-    .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.source.link"])
+    pages
+      .medicareSavingsProgramsCard()
+      .should("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.source.name"])
+      .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.summary"])
+      .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.criticalApplicationInformation"])
+      .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.eligibility.label"])
+      .and("contain", EN_CMS_MEDICARE_SAVINGS_PROGRAMS["cms-medicare-savings-programs.source.link"])
   })
 
-  it("Verify content on Pagos Concurrentes de Jubilación y de Discapacidad (CRDP) accordion is displaying correctly on Disability Spanish page", ()=> {
+  it("Verify content on Pagos Concurrentes de Jubilación y de Discapacidad (CRDP) accordion is displaying correctly on Disability Spanish page", () => {
     pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_DISABILITY["disability.title"]).click()
     pages.languageSwitcher().click()
-    pages.accordions().contains(ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.title"]).click()
-    pages.retirementAndDisabilityPaymentsCard().should("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.source.name"])
-    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.summary"])
-    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.criticalApplicationInformation"])
-    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.label"])
-    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.label1"])
-    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.acceptableValues1"])
-    .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.acceptableValues2"])
+    pages
+      .accordions()
+      .contains(ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.title"])
+      .click()
+    pages
+      .retirementAndDisabilityPaymentsCard()
+      .should(
+        "contain",
+        ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.source.name"]
+      )
+      .and("contain", ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.summary"])
+      .and(
+        "contain",
+        ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS[
+          "dod-retirement-and-disability-payments.criticalApplicationInformation"
+        ]
+      )
+      .and(
+        "contain",
+        ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.label"]
+      )
+      .and(
+        "contain",
+        ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS["dod-retirement-and-disability-payments.eligibility.label1"]
+      )
+      .and(
+        "contain",
+        ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS[
+          "dod-retirement-and-disability-payments.eligibility.acceptableValues1"
+        ]
+      )
+      .and(
+        "contain",
+        ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS[
+          "dod-retirement-and-disability-payments.eligibility.acceptableValues2"
+        ]
+      )
   })
 
-  it("Verify content on Thrift Savings Plan (TSP) accordion is displaying correctly on Retirement English page", ()=> {
+  it("Verify content on Thrift Savings Plan (TSP) accordion is displaying correctly on Retirement English page", () => {
     pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_RETIREMENT["retirement.title"]).click()
     pages.accordions().contains(EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.title"]).click()
-    pages.thriftSavingsPlanCard().should("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.source.name"])
-    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.summary"])
-    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.criticalApplicationInformation"])
-    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.eligibility.label"])
-    .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.source.link"])
+    pages
+      .thriftSavingsPlanCard()
+      .should("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.source.name"])
+      .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.summary"])
+      .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.criticalApplicationInformation"])
+      .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.eligibility.label"])
+      .and("contain", EN_DOD_THRIFT_SAVINGS_PLAN["dod-thrift-savings-plan.source.link"])
   })
 
-  it("Verify content on Programa de mejoramiento de vivienda (HIP) accordion is displaying correctly on Retirement Spanish page", ()=> {
+  it("Verify content on Programa de mejoramiento de vivienda (HIP) accordion is displaying correctly on Retirement Spanish page", () => {
     pages.otherBenefitsUsaCardGroup().contains(EN_LIFE_EVENTS_RETIREMENT["retirement.title"]).click()
     pages.languageSwitcher().click()
     pages.accordions().contains(ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.title"]).click()
-    pages.housingImprovementProgramCard().should("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.source.name"])
-    .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.summary"])
-    .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.eligibility.label"])
-    .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.source.link"])
+    pages
+      .housingImprovementProgramCard()
+      .should("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.source.name"])
+      .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.summary"])
+      .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.eligibility.label"])
+      .and("contain", ES_DOI_HOUSING_IMPROVEMENT_PROGRAM["doi-housing-improvement-program.source.link"])
   })
-
 })

--- a/cypress/support/page-objects/pages.js
+++ b/cypress/support/page-objects/pages.js
@@ -70,6 +70,24 @@ class Pages {
   buttons() {
     return cy.get(".usa-button")
   }
+  survivorBenefitsChildCard() {
+    return cy.get("#acc-content-ssa-survivor-benefits-child")
+  }
+  survivorBenefitsParentCard() {
+    return cy.get("#acc-content-ssa-survivor-benefits-parents")
+  }
+  medicareSavingsProgramsCard() {
+    return cy.get("#acc-content-cms-medicare-savings-programs")
+  }
+  retirementAndDisabilityPaymentsCard() {
+    return cy.get("#acc-content-dod-retirement-and-disability-payments")
+  }
+  thriftSavingsPlanCard(){
+    return cy.get("#acc-content-dod-thrift-savings-plan")
+  }
+  housingImprovementProgramCard() {
+    return cy.get("#acc-content-doi-housing-improvement-program")
+  }
 }
 
 export const pages = new Pages()

--- a/cypress/support/page-objects/pages.js
+++ b/cypress/support/page-objects/pages.js
@@ -82,7 +82,7 @@ class Pages {
   retirementAndDisabilityPaymentsCard() {
     return cy.get("#acc-content-dod-retirement-and-disability-payments")
   }
-  thriftSavingsPlanCard(){
+  thriftSavingsPlanCard() {
     return cy.get("#acc-content-dod-thrift-savings-plan")
   }
   housingImprovementProgramCard() {


### PR DESCRIPTION
## PR Summary

This PR adds Cypress automated tests to validate that correct content is displaying on the accordion cards. One accordion is validated in each page.
The automated test will validate accordion content on the following: -
•	Death of a loved one English page - Survivor Benefits for Child accordion
•	Death of a loved one Spanish page - Beneficios para padre/madre sobreviviente accodion
•	Disability English page - Medicare Savings Programs (MSP) accordion
•	Disability Spanish page - Pagos Concurrentes de Jubilación y de Discapacidad (CRDP) accordion
•	Retirement English page - Thrift Savings Plan (TSP) accordion
•	Retirement Spanish page - Programa de mejoramiento de vivienda (HIP) accordion

## Related Github Issue

https://github.com/GSA/usagov-benefits-eligibility/issues/911
## Type of change

- [ ] Task
- [ ] New feature

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- Pull branch
- start local
- run ```npm run cypress:run_chrome```
- Verify ```ui-render-content.cy.js``` as well as other tests, except link tests, are passing (currently there is an issue with link tests that will be addressed in https://github.com/GSA/usagov-benefits-eligibility/issues/933)

