### PR TITLE
bug fix | root redirect config causing infinite looping on iOS

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -101,7 +101,6 @@ export default {
     langDir: "locales",
     defaultLocale: "en",
     rootRedirect: {
-      statusCode: 301,
       path: "death-of-a-loved-one",
     },
   },


### PR DESCRIPTION
## PR Summary

This attempts to fix a redirect bug on iOS when nuxt configuration is set to include a 301 with the rootRedirect object.

## Related Github Issue

- fixes #936

## Type of change

- [x] Bug fix

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [x] navigate to testing environment on mobile iOS  16+  chrome and safari
- [x] ensure that infinite redirects are not occurring
- [x] ensure that only one redirect is occurring and the path includes `death-of-a-loved-one`

