### PR TITLE
933 fix failing test links in pipeline

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,7 @@ jobs:
         uses: cypress-io/github-action@v3
         with:
           browser: chrome
-          headless: true
+          headed: true
           start: npm run federalist
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,7 @@ jobs:
         uses: cypress-io/github-action@v3
         with:
           browser: chrome
-          headed: true
+          headless: true
           start: npm run federalist
 
       - uses: actions/upload-artifact@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "^28.0.2",
         "core-js": "^3.23.5",
-        "cypress": "^12.11.0",
+        "cypress": "^12.17.1",
         "date-fns": "^2.28.0",
         "eslint": "8.20.0",
         "eslint-config-prettier": "^8.5.0",
@@ -9932,13 +9932,13 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
-      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
+      "version": "12.17.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
+      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -9975,7 +9975,7 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -10166,9 +10166,9 @@
       "dev": true
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -37335,12 +37335,12 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.11.0.tgz",
-      "integrity": "sha512-TJE+CCWI26Hwr5Msb9GpQhFLubdYooW0fmlPwTsfiyxmngqc7+SZGLPeIkj2dTSSZSEtpQVzOzvcnzH0o8G7Vw==",
+      "version": "12.17.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
+      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -37377,7 +37377,7 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -37517,9 +37517,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^28.0.2",
     "core-js": "^3.23.5",
-    "cypress": "^12.11.0",
+    "cypress": "^12.17.1",
     "date-fns": "^2.28.0",
     "eslint": "8.20.0",
     "eslint-plugin-jest": "^26.2.2",


### PR DESCRIPTION
## PR Summary

This PR upgrades cypress to 12.17.1. As from Cypress 12.15.0, there is added support for chrome versions 112 and above to run headless mode that matches the headed browsers implementation

https://docs.cypress.io/guides/references/changelog

## Related Github Issue

- [Cypress links Tests error during Github pipeline run ](https://github.com/GSA/usagov-benefits-eligibility/issues/933)

## Type of change

- [x] Task
- [x] Fix Failing tests
- [x] New feature

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] Verify GitHub pipeline runs cypress workflow successfully and all the ```link.cy.js``` tests pass (https://github.com/GSA/usagov-benefits-eligibility/actions/runs/5600222174/jobs/10242298565?pr=943)
- [ ] Pull branch
- [ ] start local
- [ ] run npm run cypress:run_chrome
- [ ] Verify ```links.cy.js``` tests as well as other tests pass

