### PR TITLE
Add e2e url based configuration tests to validate benefits  display correctly based on selected criteria

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,7 +6,7 @@ module.exports = defineConfig({
   video: false,
   retries: {
     runMode: 2,
-    openMode: 2,
+    openMode: 1,
   },
   e2e: {
     baseUrl: "https://benefits-tool-demo.usa.gov/",

--- a/cypress/e2e/ui/selected-criteria-options.cy.js
+++ b/cypress/e2e/ui/selected-criteria-options.cy.js
@@ -17,9 +17,10 @@ describe("Validate selected creteria options in DOLO English Page", () => {
     //1 day = 365.2425 (accounts for leap year)
     const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
 
-    const maritalStatus = encodeURI(EN_SURVIVOR_BENEFITS_CHILD_DATA["ssa-survivor-benefits-child.eligibility.acceptableValues1"])
+    const maritalStatus = encodeURI(
+      EN_SURVIVOR_BENEFITS_CHILD_DATA["ssa-survivor-benefits-child.eligibility.acceptableValues1"]
+    )
     const applicantRelationship = encodeURI(EN_CRITERIA_DATA["criteria.applicant_relationship.values2"])
-
 
     cy.visit({
       url: `death-of-a-loved-one/?e782efd=1&b95c6d4=${dateOfBirth}&a748b56=${maritalStatus}&9d65c08=1&8f306c9=${applicantRelationship}`,
@@ -42,9 +43,13 @@ describe("Validate selected creteria options in DOLO Spanish Page", () => {
   it("Validate Beneficios para padre/madre sobreviviente accordion is rendered correctly based on selected criteria options", () => {
     //62 years ago plus one day - applicant is at least 62 years old
     const dateOfBirth = utils.getDateByOffset(-(62 * 365.2425 + 1))
-    const applicantRelationship = encodeURI(ES_SURVIVOR_BENEFITS_PARENTS_DATA["ssa-survivor-benefits-parents.eligibility.acceptableValues"])
+    const applicantRelationship = encodeURI(
+      ES_SURVIVOR_BENEFITS_PARENTS_DATA["ssa-survivor-benefits-parents.eligibility.acceptableValues"]
+    )
 
-    cy.visit({ url: `es/death-of-a-loved-one/?e782efd=1&b95c6d4=${dateOfBirth}&9d65c08=1&8f306c9=${applicantRelationship}` })
+    cy.visit({
+      url: `es/death-of-a-loved-one/?e782efd=1&b95c6d4=${dateOfBirth}&9d65c08=1&8f306c9=${applicantRelationship}`,
+    })
 
     pages
       .accordions()
@@ -63,9 +68,15 @@ describe("Validate selected creteria options in Disability English Page", () => 
   it("Validate Social Security Disability Insurance for Child with Disabilities accordion is rendered correctly based on selected criteria options", () => {
     //18 years ago plus one day - applicant at least 18 years old
     const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 + 1))
-    const applicantRelationship = encodeURI(EN_SSA_DISABILITY_INSURANCE_CHILD_DISABLED_DATA["ssa-disability-insurance-child-disabled.eligibility.acceptableValues"])
+    const applicantRelationship = encodeURI(
+      EN_SSA_DISABILITY_INSURANCE_CHILD_DISABLED_DATA[
+        "ssa-disability-insurance-child-disabled.eligibility.acceptableValues"
+      ]
+    )
 
-    cy.visit({ url: `disability/?b95c6d4=${dateOfBirth}&a748b56=${applicantRelationship}&9d65c08=1&8c5fff1=1&32c6b93=1&52fb8ed=1` })
+    cy.visit({
+      url: `disability/?b95c6d4=${dateOfBirth}&a748b56=${applicantRelationship}&9d65c08=1&8c5fff1=1&32c6b93=1&52fb8ed=1`,
+    })
 
     pages
       .accordions()
@@ -84,10 +95,16 @@ describe("Validate selected creteria options in Disability Spanish Page", () => 
   it("Validate Pagos Concurrentes de Jubilación y de Discapacidad (CRDP) accordion is rendered correctly based on selected criteria options", () => {
     //60 years ago plus one day - applicant at least 60 years old
     const dateOfBirth = utils.getDateByOffset(-(60 * 365.2425 + 1))
-    const applicantServiceStatus =  encodeURI(ES_CRITERIA_DATA["criteria.applicant_service_status.values3"])
-    const applicantServedMilitary =  encodeURI(ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS_DATA["dod-retirement-and-disability-payments.eligibility.acceptableValues"])
-    
-    cy.visit({ url: `es/disability/?b95c6d4=${dateOfBirth}&8c5fff1=1&2fe2b3a=${applicantServedMilitary}&633dad2=${applicantServiceStatus}` })
+    const applicantServiceStatus = encodeURI(ES_CRITERIA_DATA["criteria.applicant_service_status.values3"])
+    const applicantServedMilitary = encodeURI(
+      ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS_DATA[
+        "dod-retirement-and-disability-payments.eligibility.acceptableValues"
+      ]
+    )
+
+    cy.visit({
+      url: `es/disability/?b95c6d4=${dateOfBirth}&8c5fff1=1&2fe2b3a=${applicantServedMilitary}&633dad2=${applicantServiceStatus}`,
+    })
 
     pages
       .accordions()
@@ -106,7 +123,8 @@ describe("Validate selected creteria options in Retirement English Page", () => 
   it("Validate Thrift Savings Plan (TSP) accordion is rendered correctly based on selected criteria options", () => {
     //60 years ago plus one day - applicant is at least 60 years old
     const dateOfBirth = utils.getDateByOffset(-(60 * 365.2425 + 1))
-    const applicantRelationship = EN_DOD_THRIFT_SAVINGS_PLAN_DATA["dod-thrift-savings-plan.eligibility.acceptableValues"]
+    const applicantRelationship =
+      EN_DOD_THRIFT_SAVINGS_PLAN_DATA["dod-thrift-savings-plan.eligibility.acceptableValues"]
 
     cy.visit({ url: `retirement/?b95c6d4=${dateOfBirth}&2fe2b3a=${applicantRelationship}` })
 
@@ -125,8 +143,9 @@ describe("Validate selected creteria options in Retirement English Page", () => 
 
 describe("Validate selected creteria options in Retirement Spanish Page", () => {
   it("Validate Programa de mejoramiento de vivienda (HIP) accordion is rendered correctly based on selected criteria options", () => {
-    const applicantAmericanIndia = ES_DOI_HOUSING_IMPROVEMENT_PROGRAM_DATA["doi-housing-improvement-program.eligibility.acceptableValues"]
-    
+    const applicantAmericanIndia =
+      ES_DOI_HOUSING_IMPROVEMENT_PROGRAM_DATA["doi-housing-improvement-program.eligibility.acceptableValues"]
+
     cy.visit({ url: `es/retirement/?05c56fb=1&6c8cb1d=${applicantAmericanIndia}` })
 
     pages

--- a/cypress/e2e/ui/selected-criteria-options.cy.js
+++ b/cypress/e2e/ui/selected-criteria-options.cy.js
@@ -1,0 +1,143 @@
+/// <reference types="cypress"/>
+
+import { pages } from "../../support/page-objects/pages.js"
+import * as utils from "../../support/utils.js"
+import * as EN_CRITERIA_DATA from "../../../locales/en/criteria.json"
+import * as ES_CRITERIA_DATA from "../../../locales/es/criteria.json"
+import * as EN_SURVIVOR_BENEFITS_CHILD_DATA from "../../../locales/en/benefits/ssa-survivor-benefits-child.json"
+import * as ES_SURVIVOR_BENEFITS_PARENTS_DATA from "../../../locales/es/benefits/ssa-survivor-benefits-parents.json"
+import * as EN_SSA_DISABILITY_INSURANCE_CHILD_DISABLED_DATA from "../../../locales/en/benefits/ssa-disability-insurance-child-disabled.json"
+import * as ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS_DATA from "../../../locales/es/benefits/dod-retirement-and-disability-payments.json"
+import * as EN_DOD_THRIFT_SAVINGS_PLAN_DATA from "../../../locales/en/benefits/dod-thrift-savings-plan.json"
+import * as ES_DOI_HOUSING_IMPROVEMENT_PROGRAM_DATA from "../../../locales/es/benefits/doi-housing-improvement-program.json"
+
+describe("Validate selected creteria options in DOLO English Page", () => {
+  it("Validate Survivor Benefits for Child accordion is rendered correctly based on selected criteria options", () => {
+    //18 years ago minus one day - applicant under 18 years old
+    //1 day = 365.2425 (accounts for leap year)
+    const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 - 1))
+
+    const maritalStatus = encodeURI(EN_SURVIVOR_BENEFITS_CHILD_DATA["ssa-survivor-benefits-child.eligibility.acceptableValues1"])
+    const applicantRelationship = encodeURI(EN_CRITERIA_DATA["criteria.applicant_relationship.values2"])
+
+
+    cy.visit({
+      url: `death-of-a-loved-one/?e782efd=1&b95c6d4=${dateOfBirth}&a748b56=${maritalStatus}&9d65c08=1&8f306c9=${applicantRelationship}`,
+    })
+
+    pages
+      .accordions()
+      .contains(EN_SURVIVOR_BENEFITS_CHILD_DATA["ssa-survivor-benefits-child.title"])
+      .click()
+      .parent()
+      .should("have.class", "border-success-dark")
+
+    pages.survivorBenefitsChildIcons().each(($icon) => {
+      cy.wrap($icon).parent().should("have.class", "text-success-dark")
+    })
+  })
+})
+
+describe("Validate selected creteria options in DOLO Spanish Page", () => {
+  it("Validate Beneficios para padre/madre sobreviviente accordion is rendered correctly based on selected criteria options", () => {
+    //62 years ago plus one day - applicant is at least 62 years old
+    const dateOfBirth = utils.getDateByOffset(-(62 * 365.2425 + 1))
+    const applicantRelationship = encodeURI(ES_SURVIVOR_BENEFITS_PARENTS_DATA["ssa-survivor-benefits-parents.eligibility.acceptableValues"])
+
+    cy.visit({ url: `es/death-of-a-loved-one/?e782efd=1&b95c6d4=${dateOfBirth}&9d65c08=1&8f306c9=${applicantRelationship}` })
+
+    pages
+      .accordions()
+      .contains(ES_SURVIVOR_BENEFITS_PARENTS_DATA["ssa-survivor-benefits-parents.title"])
+      .click()
+      .parent()
+      .should("have.class", "border-success-dark")
+
+    pages.survivorBenefitsParentIcons().each(($icon) => {
+      cy.wrap($icon).parent().should("have.class", "text-success-dark")
+    })
+  })
+})
+
+describe("Validate selected creteria options in Disability English Page", () => {
+  it("Validate Social Security Disability Insurance for Child with Disabilities accordion is rendered correctly based on selected criteria options", () => {
+    //18 years ago plus one day - applicant at least 18 years old
+    const dateOfBirth = utils.getDateByOffset(-(18 * 365.2425 + 1))
+    const applicantRelationship = encodeURI(EN_SSA_DISABILITY_INSURANCE_CHILD_DISABLED_DATA["ssa-disability-insurance-child-disabled.eligibility.acceptableValues"])
+
+    cy.visit({ url: `disability/?b95c6d4=${dateOfBirth}&a748b56=${applicantRelationship}&9d65c08=1&8c5fff1=1&32c6b93=1&52fb8ed=1` })
+
+    pages
+      .accordions()
+      .contains(EN_SSA_DISABILITY_INSURANCE_CHILD_DISABLED_DATA["ssa-disability-insurance-child-disabled.title"])
+      .click()
+      .parent()
+      .should("have.class", "border-success-dark")
+
+    pages.disabilityInsuranceChildDisabledIcons().each(($icon) => {
+      cy.wrap($icon).parent().should("have.class", "text-success-dark")
+    })
+  })
+})
+
+describe("Validate selected creteria options in Disability Spanish Page", () => {
+  it("Validate Pagos Concurrentes de Jubilación y de Discapacidad (CRDP) accordion is rendered correctly based on selected criteria options", () => {
+    //60 years ago plus one day - applicant at least 60 years old
+    const dateOfBirth = utils.getDateByOffset(-(60 * 365.2425 + 1))
+    const applicantServiceStatus =  encodeURI(ES_CRITERIA_DATA["criteria.applicant_service_status.values3"])
+    const applicantServedMilitary =  encodeURI(ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS_DATA["dod-retirement-and-disability-payments.eligibility.acceptableValues"])
+    
+    cy.visit({ url: `es/disability/?b95c6d4=${dateOfBirth}&8c5fff1=1&2fe2b3a=${applicantServedMilitary}&633dad2=${applicantServiceStatus}` })
+
+    pages
+      .accordions()
+      .contains(ES_DOD_RETIREMENT_AND_DISABILITY_PAYMENTS_DATA["dod-retirement-and-disability-payments.title"])
+      .click()
+      .parent()
+      .should("have.class", "border-success-dark")
+
+    pages.retirementAndDisabilityPaymentsIcons().each(($icon) => {
+      cy.wrap($icon).parent().should("have.class", "text-success-dark")
+    })
+  })
+})
+
+describe("Validate selected creteria options in Retirement English Page", () => {
+  it("Validate Thrift Savings Plan (TSP) accordion is rendered correctly based on selected criteria options", () => {
+    //60 years ago plus one day - applicant is at least 60 years old
+    const dateOfBirth = utils.getDateByOffset(-(60 * 365.2425 + 1))
+    const applicantRelationship = EN_DOD_THRIFT_SAVINGS_PLAN_DATA["dod-thrift-savings-plan.eligibility.acceptableValues"]
+
+    cy.visit({ url: `retirement/?b95c6d4=${dateOfBirth}&2fe2b3a=${applicantRelationship}` })
+
+    pages
+      .accordions()
+      .contains(EN_DOD_THRIFT_SAVINGS_PLAN_DATA["dod-thrift-savings-plan.title"])
+      .click()
+      .parent()
+      .should("have.class", "border-success-dark")
+
+    pages.thriftSavingsPlanIcons().each(($icon) => {
+      cy.wrap($icon).parent().should("have.class", "text-success-dark")
+    })
+  })
+})
+
+describe("Validate selected creteria options in Retirement Spanish Page", () => {
+  it("Validate Programa de mejoramiento de vivienda (HIP) accordion is rendered correctly based on selected criteria options", () => {
+    const applicantAmericanIndia = ES_DOI_HOUSING_IMPROVEMENT_PROGRAM_DATA["doi-housing-improvement-program.eligibility.acceptableValues"]
+    
+    cy.visit({ url: `es/retirement/?05c56fb=1&6c8cb1d=${applicantAmericanIndia}` })
+
+    pages
+      .accordions()
+      .contains(ES_DOI_HOUSING_IMPROVEMENT_PROGRAM_DATA["doi-housing-improvement-program.title"])
+      .click()
+      .parent()
+      .should("have.class", "border-success-dark")
+
+    pages.housingImprovementProgramIcons().each(($icon) => {
+      cy.wrap($icon).parent().should("have.class", "text-success-dark")
+    })
+  })
+})

--- a/cypress/support/page-objects/pages.js
+++ b/cypress/support/page-objects/pages.js
@@ -73,8 +73,14 @@ class Pages {
   survivorBenefitsChildCard() {
     return cy.get("#acc-content-ssa-survivor-benefits-child")
   }
+  survivorBenefitsChildIcons() {
+    return cy.get('#acc-content-ssa-survivor-benefits-child .print\\:display-none .usa-icon')
+  }
   survivorBenefitsParentCard() {
     return cy.get("#acc-content-ssa-survivor-benefits-parents")
+  }
+  survivorBenefitsParentIcons() {
+    return cy.get("#acc-content-ssa-survivor-benefits-parents .print\\:display-none .usa-icon")
   }
   medicareSavingsProgramsCard() {
     return cy.get("#acc-content-cms-medicare-savings-programs")
@@ -82,11 +88,23 @@ class Pages {
   retirementAndDisabilityPaymentsCard() {
     return cy.get("#acc-content-dod-retirement-and-disability-payments")
   }
+  retirementAndDisabilityPaymentsIcons() {
+    return cy.get("#acc-content-dod-retirement-and-disability-payments .print\\:display-none .usa-icon")
+  }
   thriftSavingsPlanCard() {
     return cy.get("#acc-content-dod-thrift-savings-plan")
   }
+  thriftSavingsPlanIcons() {
+    return cy.get("#acc-content-dod-thrift-savings-plan .print\\:display-none .usa-icon")
+  }
   housingImprovementProgramCard() {
     return cy.get("#acc-content-doi-housing-improvement-program")
+  }
+  housingImprovementProgramIcons() {
+    return cy.get("#acc-content-doi-housing-improvement-program .print\\:display-none .usa-icon")
+  }
+  disabilityInsuranceChildDisabledIcons() {
+    return cy.get("#acc-content-ssa-disability-insurance-child-disabled  .print\\:display-none .usa-icon")
   }
 }
 

--- a/cypress/support/page-objects/pages.js
+++ b/cypress/support/page-objects/pages.js
@@ -74,7 +74,7 @@ class Pages {
     return cy.get("#acc-content-ssa-survivor-benefits-child")
   }
   survivorBenefitsChildIcons() {
-    return cy.get('#acc-content-ssa-survivor-benefits-child .print\\:display-none .usa-icon')
+    return cy.get("#acc-content-ssa-survivor-benefits-child .print\\:display-none .usa-icon")
   }
   survivorBenefitsParentCard() {
     return cy.get("#acc-content-ssa-survivor-benefits-parents")

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -1,0 +1,15 @@
+export function getDateByOffset(offset) {
+  var date = new Date(Date.now())
+  var n = Number(offset)
+
+  if (n !== n || date.toString() == "Invalid Date") {
+    return date
+  }
+
+  date.setDate(date.getDate() + n)
+  const month = date.getMonth() + 1
+  const day = date.getDate()
+  const year = date.getFullYear()
+
+  return month.toString() + "-" + day.toString() + "-" + year.toString()
+}


### PR DESCRIPTION
## PR Summary
Add e2e url based configuration tests to validate benefits  list to display correctly based on the criteria / filtered / options selected on the left.

## Related Github Issue

- Issue #(#912 )

## Type of change

- [ ] Task
- [ ] New feature

## Detailed Testing steps

- [ ] Pull branch
- [ ] start local
- [ ] run ```npm run cy:run:chrome ```

Note. There is one failure in disability due to this defect https://github.com/GSA/usagov-benefits-eligibility/issues/949

Here is the test summary
https://github.com/GSA/usagov-benefits-eligibility/actions/runs/5740187117/job/15557433642