### PR TITLE
984 run fewer tests on webkit

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [webkit, chrome, firefox, edge]
+        containers: [chrome, firefox, edge, webkit]
 
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install WebKit browser dependencies
         if: ${{ (matrix.containers == 'webkit') }}
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v4
         with:
           build: npx playwright install-deps webkit
           runTests: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -54,7 +54,6 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           browser: ${{ matrix.containers }}
-          start: npm run federalist
 
       - uses: actions/upload-artifact@v3
         if: failure ()

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [edge, webkit, chrome, firefox]
+        containers: [chrome, firefox, edge, webkit]
 
     steps:
       - name: Checkout
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install WebKit browser dependencies
         if: ${{ (matrix.containers == 'webkit') }}
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           build: npx playwright install-deps webkit
           runTests: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [chrome, firefox, edge, webkit]
+        containers: [edge, webkit, chrome, firefox]
 
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [chrome, firefox, edge, webkit]
+        containers: [webkit, chrome, firefox, edge]
 
     steps:
       - name: Checkout

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -14,5 +14,6 @@ module.exports = defineConfig({
     testIsolation: false,
     supportFile: false,
   },
+  chromeWebSecurity: false,
   experimentalWebKitSupport: true,
 })

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,9 +11,7 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: "https://benefits-tool-demo.usa.gov/",
     specPattern: "cypress/e2e/**/*.cy.{js,jsx,ts,tsx}",
-    testIsolation: false,
     supportFile: false,
   },
-  chromeWebSecurity: false,
   experimentalWebKitSupport: true,
 })

--- a/cypress/e2e/ui/accordions.cy.js
+++ b/cypress/e2e/ui/accordions.cy.js
@@ -10,7 +10,7 @@ import * as ES_BENEFITS_SSA_RETIREMENT_BENEFITS_CHILD_DISABLED from "../../../lo
 import * as EN_LIFE_EVENTS_DISABILITY from "../../../locales/en/life-events/disability.json"
 import * as EN_LIFE_EVENTS_RETIREMENT from "../../../locales/en/life-events/retirement.json"
 
-describe("Validate opening and closing of accordion cards", { browser: '!webkit' }, () => {
+describe("Validate opening and closing of accordion cards", { browser: "!webkit" }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/accordions.cy.js
+++ b/cypress/e2e/ui/accordions.cy.js
@@ -10,7 +10,7 @@ import * as ES_BENEFITS_SSA_RETIREMENT_BENEFITS_CHILD_DISABLED from "../../../lo
 import * as EN_LIFE_EVENTS_DISABILITY from "../../../locales/en/life-events/disability.json"
 import * as EN_LIFE_EVENTS_RETIREMENT from "../../../locales/en/life-events/retirement.json"
 
-describe("Validate opening and closing of accordion cards", () => {
+describe("Validate opening and closing of accordion cards", { browser: '!webkit' }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/footer.cy.js
+++ b/cypress/e2e/ui/footer.cy.js
@@ -11,7 +11,7 @@ const footerContentES = ES_DATA.footer
 const footerContentEN = EN_DATA.footer
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Footer Tests", { browser: '!webkit' }, () => {
+describe("Footer Tests", { browser: "!webkit" }, () => {
   sitePages.forEach((sitePage) => {
     it(`Validate footer content mapping in ${sitePage.name}`, () => {
       cy.visit({ url: sitePage.route })

--- a/cypress/e2e/ui/footer.cy.js
+++ b/cypress/e2e/ui/footer.cy.js
@@ -11,7 +11,7 @@ const footerContentES = ES_DATA.footer
 const footerContentEN = EN_DATA.footer
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Footer Tests", () => {
+describe("Footer Tests", { browser: '!webkit' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Validate footer content mapping in ${sitePage.name}`, () => {
       cy.visit({ url: sitePage.route })

--- a/cypress/e2e/ui/header.cy.js
+++ b/cypress/e2e/ui/header.cy.js
@@ -2,7 +2,7 @@
 
 import { pages } from "../../support/page-objects/pages.js"
 
-describe("Header Tests", { browser: '!webkit' }, () => {
+describe("Header Tests", { browser: "!webkit" }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/header.cy.js
+++ b/cypress/e2e/ui/header.cy.js
@@ -2,7 +2,7 @@
 
 import { pages } from "../../support/page-objects/pages.js"
 
-describe("Header Tests", () => {
+describe("Header Tests", { browser: '!webkit' }, () => {
   before(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/header.cy.js
+++ b/cypress/e2e/ui/header.cy.js
@@ -3,7 +3,7 @@
 import { pages } from "../../support/page-objects/pages.js"
 
 describe("Header Tests", { browser: '!webkit' }, () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit("/")
   })
 

--- a/cypress/e2e/ui/links.cy.js
+++ b/cypress/e2e/ui/links.cy.js
@@ -4,7 +4,7 @@ import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Verify correct status code when user navigates links", () => {
+describe("Verify correct status code when user navigates links", { browser: '!webkit' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify success status code response for links in ${sitePage.name} `, () => {
       cy.visit({ url: sitePage.route })

--- a/cypress/e2e/ui/links.cy.js
+++ b/cypress/e2e/ui/links.cy.js
@@ -4,7 +4,7 @@ import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Verify correct status code when user navigates links", { browser: '!webkit' }, () => {
+describe("Verify correct status code when user navigates links", { browser: 'chrome' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify success status code response for links in ${sitePage.name} `, () => {
       cy.visit({ url: sitePage.route })

--- a/cypress/e2e/ui/links.cy.js
+++ b/cypress/e2e/ui/links.cy.js
@@ -4,18 +4,16 @@ import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-const excludedlinks = [ "https://www.instagram.com/usagov/"]
+const excludedlinks = ["https://www.instagram.com/usagov/"]
 
-
-describe("Verify correct status code when user navigates links", { browser: 'chrome' }, () => {
+describe("Verify correct status code when user navigates links", { browser: "chrome" }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify success status code response for links in ${sitePage.name} `, () => {
       cy.visit({ url: sitePage.route })
       cy.get("a[href]").each((link) => {
-        if (excludedlinks.indexOf(link.prop('href')) == -1) {
+        if (excludedlinks.indexOf(link.prop("href")) == -1) {
           cy.request(link.prop("href"))
         }
-       
       })
     })
   })

--- a/cypress/e2e/ui/links.cy.js
+++ b/cypress/e2e/ui/links.cy.js
@@ -4,12 +4,18 @@ import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
+const excludedlinks = [ "https://www.instagram.com/usagov/"]
+
+
 describe("Verify correct status code when user navigates links", { browser: 'chrome' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify success status code response for links in ${sitePage.name} `, () => {
       cy.visit({ url: sitePage.route })
       cy.get("a[href]").each((link) => {
-        cy.request(link.prop("href"))
+        if (excludedlinks.indexOf(link.prop('href')) == -1) {
+          cy.request(link.prop("href"))
+        }
+       
       })
     })
   })

--- a/cypress/e2e/ui/open-all-close-all-button.cy.js
+++ b/cypress/e2e/ui/open-all-close-all-button.cy.js
@@ -5,7 +5,7 @@ import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Validate Open All button functionality", () => {
+describe("Validate Open All button functionality", { browser: '!webkit' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify Open All button should open all accordion cards in ${sitePage.name}`, () => {
       cy.visit({ url: sitePage.route })
@@ -17,7 +17,7 @@ describe("Validate Open All button functionality", () => {
   })
 })
 
-describe("Validate Close All button functionality", () => {
+describe("Validate Close All button functionality", { browser: '!webkit' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify Close All button should close all accordion cards in ${sitePage.name}`, () => {
       cy.visit({ url: sitePage.route })

--- a/cypress/e2e/ui/open-all-close-all-button.cy.js
+++ b/cypress/e2e/ui/open-all-close-all-button.cy.js
@@ -5,7 +5,7 @@ import * as SITE_PAGES_DATA from "../../fixtures/site-pages.json"
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Validate Open All button functionality", { browser: '!webkit' }, () => {
+describe("Validate Open All button functionality", { browser: "!webkit" }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify Open All button should open all accordion cards in ${sitePage.name}`, () => {
       cy.visit({ url: sitePage.route })
@@ -17,7 +17,7 @@ describe("Validate Open All button functionality", { browser: '!webkit' }, () =>
   })
 })
 
-describe("Validate Close All button functionality", { browser: '!webkit' }, () => {
+describe("Validate Close All button functionality", { browser: "!webkit" }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify Close All button should close all accordion cards in ${sitePage.name}`, () => {
       cy.visit({ url: sitePage.route })

--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -8,7 +8,7 @@ describe("Select criteria and print selections", () => {
     cy.visit("/")
   })
 
-  it("Select a criteria and stub printing when user clicks Print My Selections", () => {
+  it("Select a criteria and stub printing when user clicks Print My Selections", { browser: '!webkit' }, () => {
     pages.checkboxLabels().contains(EN_CRITERIA["criteria.deceased_death_location_is_US.label"]).click()
     cy.window().then((win) => {
       cy.stub(win, "print").as("print")

--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -3,12 +3,12 @@
 import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 
-describe("Select criteria and print selections", () => {
+describe("Select criteria and print selections", { browser: '!webkit' }, () => {
   before(() => {
     cy.visit("/")
   })
 
-  it("Select a criteria and stub printing when user clicks Print My Selections", { browser: '!webkit' }, () => {
+  it("Select a criteria and stub printing when user clicks Print My Selections", () => {
     pages.checkboxLabels().contains(EN_CRITERIA["criteria.deceased_death_location_is_US.label"]).click()
     cy.window().then((win) => {
       cy.stub(win, "print").as("print")

--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -3,7 +3,7 @@
 import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 
-describe("Select criteria and print selections", { browser: '!webkit' }, () => {
+describe("Select criteria and print selections", { browser: "!webkit" }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/print-selections.cy.js
+++ b/cypress/e2e/ui/print-selections.cy.js
@@ -4,7 +4,7 @@ import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 
 describe("Select criteria and print selections", { browser: '!webkit' }, () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit("/")
   })
 

--- a/cypress/e2e/ui/sort-benefits-list.cy.js
+++ b/cypress/e2e/ui/sort-benefits-list.cy.js
@@ -4,7 +4,7 @@ import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 import * as EN_BENEFITS_COVID_19 from "../../../locales/en/benefits/fema-covid-19-funeral-assistance.json"
 
-describe("Sort benefits accordion list using Covid 19 filter", () => {
+describe("Sort benefits accordion list using Covid 19 filter", { browser: '!webkit' }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/sort-benefits-list.cy.js
+++ b/cypress/e2e/ui/sort-benefits-list.cy.js
@@ -4,7 +4,7 @@ import { pages } from "../../support/page-objects/pages.js"
 import * as EN_CRITERIA from "../../../locales/en/criteria.json"
 import * as EN_BENEFITS_COVID_19 from "../../../locales/en/benefits/fema-covid-19-funeral-assistance.json"
 
-describe("Sort benefits accordion list using Covid 19 filter", { browser: '!webkit' }, () => {
+describe("Sort benefits accordion list using Covid 19 filter", { browser: "!webkit" }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/ui-render-content.cy.js
+++ b/cypress/e2e/ui/ui-render-content.cy.js
@@ -13,7 +13,7 @@ import * as EN_LIFE_EVENTS_RETIREMENT from "../../../locales/en/life-events/reti
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Verify UI is rendering content correctly", { browser: '!webkit' }, () => {
+describe("Verify UI is rendering content correctly", { browser: "!webkit" }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify ${sitePage.name} is rendering content correctly instead of dot notation value on checkbox labels`, () => {
       cy.visit({ url: sitePage.route })
@@ -25,7 +25,7 @@ describe("Verify UI is rendering content correctly", { browser: '!webkit' }, () 
   })
 })
 
-describe("Verify Benefits Card content is displaying correctly", { browser: '!webkit' }, () => {
+describe("Verify Benefits Card content is displaying correctly", { browser: "!webkit" }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/cypress/e2e/ui/ui-render-content.cy.js
+++ b/cypress/e2e/ui/ui-render-content.cy.js
@@ -13,7 +13,7 @@ import * as EN_LIFE_EVENTS_RETIREMENT from "../../../locales/en/life-events/reti
 
 const sitePages = SITE_PAGES_DATA.sitePages
 
-describe("Verify UI is rendering content correctly", () => {
+describe("Verify UI is rendering content correctly", { browser: '!webkit' }, () => {
   sitePages.forEach((sitePage) => {
     it(`Verify ${sitePage.name} is rendering content correctly instead of dot notation value on checkbox labels`, () => {
       cy.visit({ url: sitePage.route })
@@ -25,7 +25,7 @@ describe("Verify UI is rendering content correctly", () => {
   })
 })
 
-describe("Verify Benefits Card content is displaying correctly", () => {
+describe("Verify Benefits Card content is displaying correctly", { browser: '!webkit' }, () => {
   beforeEach(() => {
     cy.visit("/")
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "nuxt": "^2.15.8",
         "pa11y": "^6.2.3",
         "path-parse": ">=1.0.7",
-        "playwright-webkit": "^1.36.2",
+        "playwright-webkit": "^1.34",
         "prettier": "^2.6.2",
         "prismjs": "^1.27.0",
         "sass": "^1.50.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "nuxt": "^2.15.8",
         "pa11y": "^6.2.3",
         "path-parse": ">=1.0.7",
-        "playwright-webkit": "^1.34",
+        "playwright-webkit": "^1.37.1",
         "prettier": "^2.6.2",
         "prismjs": "^1.27.0",
         "sass": "^1.50.1",
@@ -21580,9 +21580,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
-      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -21592,13 +21592,13 @@
       }
     },
     "node_modules/playwright-webkit": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.36.2.tgz",
-      "integrity": "sha512-tvGCLKrT0NO2ElJjSJQ4MKFAUgUIAN1h7vZImwaE5G/odRrQyhLXF0SdJB6qfUojiYL2pONr3Wzp7iqJ+EtlnA==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.37.1.tgz",
+      "integrity": "sha512-evRNDTDgcBpKbLHbY8YKJq0LTKaRxmvhIyZHGljIc42mtmID15wkQXXVJAc90ohV0UVRw9y83k57IMjoA/xEyw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.36.2"
+        "playwright-core": "1.37.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -46348,18 +46348,18 @@
       }
     },
     "playwright-core": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
-      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
+      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
       "dev": true
     },
     "playwright-webkit": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.36.2.tgz",
-      "integrity": "sha512-tvGCLKrT0NO2ElJjSJQ4MKFAUgUIAN1h7vZImwaE5G/odRrQyhLXF0SdJB6qfUojiYL2pONr3Wzp7iqJ+EtlnA==",
+      "version": "1.37.1",
+      "resolved": "https://registry.npmjs.org/playwright-webkit/-/playwright-webkit-1.37.1.tgz",
+      "integrity": "sha512-evRNDTDgcBpKbLHbY8YKJq0LTKaRxmvhIyZHGljIc42mtmID15wkQXXVJAc90ohV0UVRw9y83k57IMjoA/xEyw==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.36.2"
+        "playwright-core": "1.37.1"
       }
     },
     "plugin-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "^28.0.2",
         "core-js": "^3.23.5",
-        "cypress": "^12.17.3",
+        "cypress": "^12.17.4",
         "date-fns": "^2.28.0",
         "eslint": "8.20.0",
         "eslint-config-prettier": "^8.5.0",
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.11",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
-      "integrity": "sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==",
+      "version": "2.88.12",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
+      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -1824,7 +1824,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.10.3",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -1844,19 +1844,6 @@
       },
       "engines": {
         "node": ">= 0.12"
-      }
-    },
-    "node_modules/@cypress/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/@cypress/xvfb": {
@@ -9933,13 +9920,13 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.17.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
-      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
+      "version": "12.17.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "2.88.12",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -9974,6 +9961,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -23353,6 +23341,12 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -26499,17 +26493,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -27286,6 +27290,16 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/url/node_modules/punycode": {
@@ -30742,9 +30756,9 @@
       "dev": true
     },
     "@cypress/request": {
-      "version": "2.88.11",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
-      "integrity": "sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==",
+      "version": "2.88.12",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
+      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -30762,7 +30776,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.10.3",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -30776,16 +30790,6 @@
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-          "dev": true,
-          "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
           }
         }
       }
@@ -37364,12 +37368,12 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.17.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
-      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
+      "version": "12.17.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "2.88.12",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -37404,6 +37408,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -47801,6 +47806,12 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -50332,14 +50343,23 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+          "dev": true
+        }
       }
     },
     "tr46": {
@@ -50934,6 +50954,16 @@
             "json5": "^2.1.2"
           }
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "use": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "^28.0.2",
         "core-js": "^3.23.5",
-        "cypress": "^12.17.4",
+        "cypress": "^13.1.0",
         "date-fns": "^2.28.0",
         "eslint": "8.20.0",
         "eslint-config-prettier": "^8.5.0",
@@ -1804,9 +1804,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -1822,7 +1822,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -9920,13 +9920,13 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -9974,7 +9974,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -23295,9 +23295,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -30756,9 +30756,9 @@
       "dev": true
     },
     "@cypress/request": {
-      "version": "2.88.12",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.12.tgz",
-      "integrity": "sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
+      "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -30774,7 +30774,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "~6.10.3",
+        "qs": "6.10.4",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
@@ -37368,12 +37368,12 @@
       "dev": true
     },
     "cypress": {
-      "version": "12.17.4",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
-      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "requires": {
-        "@cypress/request": "2.88.12",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -47776,9 +47776,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
+      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^28.0.2",
     "core-js": "^3.23.5",
-    "cypress": "^12.17.4",
+    "cypress": "^13.1.0",
     "date-fns": "^2.28.0",
     "eslint": "8.20.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^28.0.2",
     "core-js": "^3.23.5",
-    "cypress": "^12.17.3",
+    "cypress": "^12.17.4",
     "date-fns": "^2.28.0",
     "eslint": "8.20.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "nuxt": "^2.15.8",
     "pa11y": "^6.2.3",
     "path-parse": ">=1.0.7",
-    "playwright-webkit": "^1.34",
+    "playwright-webkit": "^1.37.1",
     "prettier": "^2.6.2",
     "prismjs": "^1.27.0",
     "sass": "^1.50.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "nuxt": "^2.15.8",
     "pa11y": "^6.2.3",
     "path-parse": ">=1.0.7",
-    "playwright-webkit": "^1.36.2",
+    "playwright-webkit": "^1.34",
     "prettier": "^2.6.2",
     "prismjs": "^1.27.0",
     "sass": "^1.50.1",


### PR DESCRIPTION
## PR Summary
Given the tests are covered in other browsers, in this PR we are reducing the number of tests that run on webkit (safari).
E2E tests are the slowest to execute and can be more brittle due to their dependence on the user interface and external dependencies. 

## Related Github Issue

- fixes #(https://github.com/GSA/usagov-benefits-eligibility/issues/984)

## Type of change

- [ ] Task

## Detailed Testing steps

Link to testing steps in the issue or list them here:

- [ ] In the actions tab, run the cypress workflow against this branch and verify that webkit tests pass.
